### PR TITLE
之前提交的配合nginx一致性hash模块的patch有问题

### DIFF
--- a/src/main/java/net/rubyeye/xmemcached/impl/KetamaMemcachedSessionLocator.java
+++ b/src/main/java/net/rubyeye/xmemcached/impl/KetamaMemcachedSessionLocator.java
@@ -11,6 +11,7 @@
  */
 package net.rubyeye.xmemcached.impl;
 
+import java.net.InetSocketAddress;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -57,6 +58,7 @@ public class KetamaMemcachedSessionLocator extends
 	/**
 	 * compatible with nginx-upstream-consistent,patched by wolfg1969
 	 */
+    static final int DEFAULT_PORT = 11211;
 	private final boolean cwNginxUpstreamConsistent;
 
 	public KetamaMemcachedSessionLocator() {
@@ -93,10 +95,11 @@ public class KetamaMemcachedSessionLocator extends
 		String sockStr;
 		for (Session session : list) {
 			if (this.cwNginxUpstreamConsistent) {
-				sockStr = String.format("%s:%d",
-						session.getRemoteSocketAddress().getAddress()
-								.getHostAddress(), session
-								.getRemoteSocketAddress().getPort());
+                InetSocketAddress serverAddress = session.getRemoteSocketAddress();
+                sockStr = serverAddress.getAddress().getHostAddress();
+                if (serverAddress.getPort() != DEFAULT_PORT) {
+                    sockStr = sockStr + ":" + serverAddress.getPort();
+                }
 			} else {
 				sockStr = String.valueOf(session.getRemoteSocketAddress());
 			}

--- a/src/test/java/net/rubyeye/xmemcached/test/unittest/impl/KetamaMemcachedSessionLocatorNginxUpstreamConsistentUnitTest.java
+++ b/src/test/java/net/rubyeye/xmemcached/test/unittest/impl/KetamaMemcachedSessionLocatorNginxUpstreamConsistentUnitTest.java
@@ -1,0 +1,233 @@
+package net.rubyeye.xmemcached.test.unittest.impl;
+
+import com.google.code.yanf4j.core.CodecFactory;
+import com.google.code.yanf4j.core.Handler;
+import com.google.code.yanf4j.core.Session;
+import net.rubyeye.xmemcached.impl.KetamaMemcachedSessionLocator;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.nio.ByteOrder;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+public class KetamaMemcachedSessionLocatorNginxUpstreamConsistentUnitTest extends
+		AbstractMemcachedSessionLocatorUnitTest {
+
+    static private class MockSession implements Session {
+
+        private boolean closed = false;
+        private final String host;
+        private final int port;
+
+        public MockSession(String host, int port) {
+            this.host = host;
+            this.port = port;
+        }
+
+        public void start() {
+        }
+
+        public void write(Object packet) {
+        }
+
+        public boolean isClosed() {
+            return this.closed;
+        }
+
+        public void close() {
+            this.closed = true;
+        }
+
+        public InetSocketAddress getRemoteSocketAddress() {
+            return new InetSocketAddress(this.host, this.port);
+        }
+
+        public InetAddress getLocalAddress() {
+            return null;
+        }
+
+        public boolean isUseBlockingWrite() {
+            return false;
+        }
+
+        public void setUseBlockingWrite(boolean useBlockingWrite) {
+        }
+
+        public boolean isUseBlockingRead() {
+            return false;
+        }
+
+        public void setUseBlockingRead(boolean useBlockingRead) {
+        }
+
+        public void flush() {
+        }
+
+        public boolean isExpired() {
+            return false;
+        }
+
+        public boolean isIdle() {
+            return false;
+        }
+
+        public CodecFactory.Encoder getEncoder() {
+            return null;
+        }
+
+        public void setEncoder(CodecFactory.Encoder encoder) {
+        }
+
+        public CodecFactory.Decoder getDecoder() {
+            return null;
+        }
+
+        public void setDecoder(CodecFactory.Decoder decoder) {
+        }
+
+        public boolean isHandleReadWriteConcurrently() {
+            return false;
+        }
+
+        public void setHandleReadWriteConcurrently(boolean handleReadWriteConcurrently) {
+        }
+
+        public ByteOrder getReadBufferByteOrder() {
+            return null;
+        }
+
+        public void setReadBufferByteOrder(ByteOrder readBufferByteOrder) {
+        }
+
+        public void setAttribute(String key, Object value) {
+        }
+
+        public void removeAttribute(String key) {
+        }
+
+        public Object getAttribute(String key) {
+            return null;
+        }
+
+        public void clearAttributes() {
+        }
+
+        public long getScheduleWritenBytes() {
+            return 0;
+        }
+
+        public long getLastOperationTimeStamp() {
+            return 0;
+        }
+
+        public boolean isLoopbackConnection() {
+            return false;
+        }
+
+        public long getSessionIdleTimeout() {
+            return 0;
+        }
+
+        public void setSessionIdleTimeout(long sessionIdleTimeout) {
+        }
+
+        public long getSessionTimeout() {
+            return 0;
+        }
+
+        public void setSessionTimeout(long sessionTimeout) {
+        }
+
+        public Object setAttributeIfAbsent(String key, Object value) {
+            return null;
+        }
+
+        public Handler getHandler() {
+            return null;
+        }
+    }
+
+	@Before
+	public void setUp() {
+		this.locator = new KetamaMemcachedSessionLocator();
+	}
+
+	@Test
+	public void testSessionKey_CompatibleWithNginxUpstreamConsistent() {
+
+		this.locator = new KetamaMemcachedSessionLocator(true);
+
+		MockSession session1 = new MockSession("127.0.0.1", 11211);
+		MockSession session2 = new MockSession("127.0.0.1", 11212);
+		MockSession session3 = new MockSession("127.0.0.1", 11213);
+		List<Session> list = new ArrayList<Session>();
+		list.add(session1);
+		list.add(session2);
+        list.add(session3);
+		this.locator.updateSessions(list);
+
+		assertEquals(session1.getRemoteSocketAddress(), this.locator
+				.getSessionByKey("127.0.0.1-0").getRemoteSocketAddress());
+        assertEquals(session1.getRemoteSocketAddress(), this.locator
+                .getSessionByKey("127.0.0.1-1").getRemoteSocketAddress());
+        assertEquals(session1.getRemoteSocketAddress(), this.locator
+                .getSessionByKey("127.0.0.1-39").getRemoteSocketAddress());
+
+		assertEquals(session2.getRemoteSocketAddress(), this.locator
+				.getSessionByKey("127.0.0.1:11212-0").getRemoteSocketAddress());
+        assertEquals(session2.getRemoteSocketAddress(), this.locator
+                .getSessionByKey("127.0.0.1:11212-1").getRemoteSocketAddress());
+        assertEquals(session2.getRemoteSocketAddress(), this.locator
+                .getSessionByKey("127.0.0.1:11212-39").getRemoteSocketAddress());
+
+		assertEquals(session3.getRemoteSocketAddress(), this.locator
+				.getSessionByKey("127.0.0.1:11213-0").getRemoteSocketAddress());
+        assertEquals(session3.getRemoteSocketAddress(), this.locator
+                .getSessionByKey("127.0.0.1:11213-1").getRemoteSocketAddress());
+        assertEquals(session3.getRemoteSocketAddress(), this.locator
+                .getSessionByKey("127.0.0.1:11213-39").getRemoteSocketAddress());
+
+	}
+
+    @Test
+    public void testSessionKey_CompatibleWithNginxUpstreamConsistent_DefaultPort() {
+
+        this.locator = new KetamaMemcachedSessionLocator(true);
+
+        MockSession session1 = new MockSession("192.168.1.1", 11211);
+        MockSession session2 = new MockSession("192.168.1.2", 11211);
+        MockSession session3 = new MockSession("192.168.1.3", 11211);
+        List<Session> list = new ArrayList<Session>();
+        list.add(session1);
+        list.add(session2);
+        list.add(session3);
+        this.locator.updateSessions(list);
+
+        assertEquals(session1.getRemoteSocketAddress(), this.locator
+                .getSessionByKey("192.168.1.1-0").getRemoteSocketAddress());
+        assertEquals(session1.getRemoteSocketAddress(), this.locator
+                .getSessionByKey("192.168.1.1-1").getRemoteSocketAddress());
+        assertEquals(session1.getRemoteSocketAddress(), this.locator
+                .getSessionByKey("192.168.1.1-39").getRemoteSocketAddress());
+
+        assertEquals(session2.getRemoteSocketAddress(), this.locator
+                .getSessionByKey("192.168.1.2-0").getRemoteSocketAddress());
+        assertEquals(session2.getRemoteSocketAddress(), this.locator
+                .getSessionByKey("192.168.1.2-1").getRemoteSocketAddress());
+        assertEquals(session2.getRemoteSocketAddress(), this.locator
+                .getSessionByKey("192.168.1.2-39").getRemoteSocketAddress());
+
+        assertEquals(session3.getRemoteSocketAddress(), this.locator
+                .getSessionByKey("192.168.1.3-0").getRemoteSocketAddress());
+        assertEquals(session3.getRemoteSocketAddress(), this.locator
+                .getSessionByKey("192.168.1.3-1").getRemoteSocketAddress());
+        assertEquals(session3.getRemoteSocketAddress(), this.locator
+                .getSessionByKey("192.168.1.3-39").getRemoteSocketAddress());
+
+    }
+}

--- a/src/test/java/net/rubyeye/xmemcached/test/unittest/impl/KetamaMemcachedSessionLocatorUnitTest.java
+++ b/src/test/java/net/rubyeye/xmemcached/test/unittest/impl/KetamaMemcachedSessionLocatorUnitTest.java
@@ -97,26 +97,4 @@ public class KetamaMemcachedSessionLocatorUnitTest extends
 		assertSame(session2, this.locator.getSessionByKey("a3"));
 	}
 
-	@Test
-	public void testSessionKey_CompatibleWithNginxUpstreamConsistent() {
-
-		this.locator = new KetamaMemcachedSessionLocator(true);
-
-		MockSession session1 = new MockSession(8080);
-		MockSession session2 = new MockSession(8081);
-		MockSession session3 = new MockSession(8082);
-		List<Session> list = new ArrayList<Session>();
-		list.add(session1);
-		list.add(session2);
-		list.add(session3);
-		this.locator.updateSessions(list);
-
-		assertEquals(session1.getRemoteSocketAddress(), this.locator
-				.getSessionByKey("127.0.0.1:8080-1").getRemoteSocketAddress());
-		assertEquals(session2.getRemoteSocketAddress(), this.locator
-				.getSessionByKey("127.0.0.1:8081-2").getRemoteSocketAddress());
-		assertEquals(session3.getRemoteSocketAddress(), this.locator
-				.getSessionByKey("127.0.0.1:8082-3").getRemoteSocketAddress());
-
-	}
 }


### PR DESCRIPTION
Google Code [Issue 145](http://code.google.com/p/xmemcached/issues/detail?id=145) 当使用默认端口11211时还是找不到正确的server，因为Nginx模块那边忽略了默认端口。这次还把相关的单元测试独立出来了。
