### PR TITLE
Add a convenience constructor to pass a String instead of a list of InetSocketAddress

### DIFF
--- a/src/main/java/net/rubyeye/xmemcached/XMemcachedClientBuilder.java
+++ b/src/main/java/net/rubyeye/xmemcached/XMemcachedClientBuilder.java
@@ -17,6 +17,7 @@ import net.rubyeye.xmemcached.impl.DefaultKeyProvider;
 import net.rubyeye.xmemcached.transcoders.SerializingTranscoder;
 import net.rubyeye.xmemcached.transcoders.Transcoder;
 import net.rubyeye.xmemcached.utils.Protocol;
+import net.rubyeye.xmemcached.utils.AddrUtil;
 
 import com.google.code.yanf4j.config.Configuration;
 import com.google.code.yanf4j.core.SocketOption;
@@ -177,6 +178,10 @@ public class XMemcachedClientBuilder implements MemcachedClientBuilder {
 
 	private @SuppressWarnings("unchecked")
 	Transcoder transcoder = new SerializingTranscoder();
+
+	public XMemcachedClientBuilder(String addressList) {
+		this(AddrUtil.getAddresses(addressList));
+	}
 
 	public XMemcachedClientBuilder(List<InetSocketAddress> addressList) {
 		if (addressList != null) {


### PR DESCRIPTION
I am using Spring 3 and want to pass the list of servers through a property.
Having to do the following is not convenient:

```
                <constructor-arg>
                        <list>
                                <bean class="java.net.InetSocketAddress">
                                        <constructor-arg>
                                                <value>localhost</value>
                                        </constructor-arg>
                                        <constructor-arg>
                                                <value>12000</value>
                                        </constructor-arg>
                                </bean>
                                <bean class="java.net.InetSocketAddress">
                                        <constructor-arg>
                                                <value>localhost</value>
                                        </constructor-arg>
                                        <constructor-arg>
                                                <value>12001</value>
                                        </constructor-arg>
                                </bean>
                        </list>
                </constructor-arg>
```

So this change just add a convenience constructor to pass a String. This string being parsed by AddrUtil.getAddresses()

Now I can just pass the following:
`<constructor-arg value="${my.memcache.servers}"/>`
