### PR TITLE
KeyProvider + namespace 一起使用时, 会有一点小问题,  请作者审查下

### DIFF
--- a/src/main/java/net/rubyeye/xmemcached/XMemcachedClient.java
+++ b/src/main/java/net/rubyeye/xmemcached/XMemcachedClient.java
@@ -2691,7 +2691,7 @@ public class XMemcachedClient implements XMemcachedClientMBean, MemcachedClient 
 	 */
 	public String getNamespace(String ns) throws TimeoutException,
 			InterruptedException, MemcachedException {
-		String key = this.getNSKey(ns);
+		String key = this.keyProvider.process(this.getNSKey(ns));
 		byte[] keyBytes = ByteUtils.getBytes(key);
 		ByteUtils.checkKey(keyBytes);
 		Object item = this.fetch0(key, keyBytes, CommandType.GET_ONE,

--- a/src/test/java/net/rubyeye/xmemcached/test/unittest/XMemcachedClientWithKeyProviderTest.java
+++ b/src/test/java/net/rubyeye/xmemcached/test/unittest/XMemcachedClientWithKeyProviderTest.java
@@ -1,0 +1,68 @@
+package net.rubyeye.xmemcached.test.unittest;
+
+import java.util.concurrent.TimeoutException;
+
+import net.rubyeye.xmemcached.KeyProvider;
+import net.rubyeye.xmemcached.MemcachedClient;
+import net.rubyeye.xmemcached.MemcachedClientBuilder;
+import net.rubyeye.xmemcached.MemcachedClientCallable;
+import net.rubyeye.xmemcached.XMemcachedClientBuilder;
+import net.rubyeye.xmemcached.command.BinaryCommandFactory;
+import net.rubyeye.xmemcached.exception.MemcachedException;
+import net.rubyeye.xmemcached.utils.AddrUtil;
+import net.rubyeye.xmemcached.utils.ByteUtils;
+
+public class XMemcachedClientWithKeyProviderTest extends XMemcachedClientTest{
+	
+	private KeyProvider keyProvider;
+	
+	@Override
+	public void setUp() throws Exception {
+		super.setUp();
+		keyProvider = new KeyProvider() {
+			
+			public String process(String key) {
+				// 现实中是基于某种规则进行字符串转换, 为了简单, 我直接用hashCode
+				return String.valueOf(key.hashCode());
+			}
+		};
+	}
+	
+	@Override
+	public MemcachedClientBuilder createBuilder() throws Exception {
+
+		MemcachedClientBuilder builder = new XMemcachedClientBuilder(AddrUtil
+				.getAddresses(this.properties
+						.getProperty("test.memcached.servers")));
+		builder.setCommandFactory(new BinaryCommandFactory());
+		ByteUtils.testing = true;
+		return builder;
+	}
+	
+	public void testKeyProvider(){
+		String process = keyProvider.process("namespace:a");
+		assertEquals("790852098", process);
+	}
+	
+	public void testWithNamespaceAndKeyProvider() throws Exception{
+		memcachedClient.setKeyProvider(keyProvider);
+		memcachedClient.withNamespace("a", new MemcachedClientCallable<Void>() {
+
+			public Void call(MemcachedClient client) throws MemcachedException, InterruptedException, TimeoutException {
+				client.set("name", 0, "Mike Liu");
+				return null;
+			}
+		});
+		
+		memcachedClient.invalidateNamespace("a");
+		
+		Object result = memcachedClient.withNamespace("a", new MemcachedClientCallable<Object>() {
+			public Object call(MemcachedClient client) throws MemcachedException, InterruptedException, TimeoutException {
+				return memcachedClient.get("name");
+			}
+		});
+		
+		assertNull(result);
+	}
+	
+}


### PR DESCRIPTION
正在写一个基于memcached的mybatis的缓存, 所以有使用到您的xmemcached, 由于mybatis的缓存key使用的是sql+一些参数+一些的值,  一般都超过了250个字符, 所以就写了一个KeyProvider缩小字符串的长度, 但同时又使用了namespace, 所以就遇到问题了...
