### PR TITLE
squid:S1244,squid:S1444 Fixing the imprecise floating point numbers comparison and adding final keyword

### DIFF
--- a/src/main/java/com/google/code/yanf4j/config/Configuration.java
+++ b/src/main/java/com/google/code/yanf4j/config/Configuration.java
@@ -70,7 +70,7 @@ public class Configuration {
 	/**
 	 * Max read buffer size for connection
 	 */
-	public static int MAX_READ_BUFFER_SIZE = 128 * 1024;
+	public final static int MAX_READ_BUFFER_SIZE = 128 * 1024;
 
 	/**
 	 * check session idle interval

--- a/src/main/java/com/google/code/yanf4j/core/impl/PoolDispatcher.java
+++ b/src/main/java/com/google/code/yanf4j/core/impl/PoolDispatcher.java
@@ -40,8 +40,8 @@ import com.google.code.yanf4j.util.WorkerThreadFactory;
  * 
  */
 public class PoolDispatcher implements Dispatcher {
-	public static int POOL_QUEUE_SIZE_FACTOR = 1000;
-	public static float MAX_POOL_SIZE_FACTOR = 1.25f;
+	public static final int POOL_QUEUE_SIZE_FACTOR = 1000;
+	public static final float MAX_POOL_SIZE_FACTOR = 1.25f;
 	private ThreadPoolExecutor threadPool;
 
 	public PoolDispatcher(int poolSize) {

--- a/src/main/java/net/rubyeye/xmemcached/transcoders/CachedData.java
+++ b/src/main/java/net/rubyeye/xmemcached/transcoders/CachedData.java
@@ -13,7 +13,7 @@ public final class CachedData {
 	/**
 	 * Maximum data size allowed by memcached.
 	 */
-	public static int MAX_SIZE = 1024 * 1024;
+	public final static int MAX_SIZE = 1024 * 1024;
 
 	protected int flag;
 	protected long cas;

--- a/src/test/java/net/rubyeye/xmemcached/helper/AbstractChecker.java
+++ b/src/test/java/net/rubyeye/xmemcached/helper/AbstractChecker.java
@@ -5,6 +5,7 @@ import junit.framework.ComparisonFailure;
 
 public abstract class AbstractChecker implements ExceptionChecker {
 
+	private static final double EPSILON =  0.00000001;
 	public void call() throws Exception {
 		// TODO Auto-generated method stub
 		
@@ -108,7 +109,7 @@ public abstract class AbstractChecker implements ExceptionChecker {
 		// NaN and the
 		// the following test fails
 		if (Double.isInfinite(expected)) {
-			if (!(expected == actual))
+			if (!(Math.abs(expected - actual) <= EPSILON))
 				failNotEquals(message, new Double(expected), new Double(actual));
 		} else if (!(Math.abs(expected - actual) <= delta)) // Because
 															// comparison with
@@ -136,7 +137,7 @@ public abstract class AbstractChecker implements ExceptionChecker {
 		// NaN and the
 		// the following test fails
 		if (Float.isInfinite(expected)) {
-			if (!(expected == actual))
+			if (!(Math.abs(expected - actual) <= EPSILON))
 				failNotEquals(message, new Float(expected), new Float(actual));
 		} else if (!(Math.abs(expected - actual) <= delta))
 			failNotEquals(message, new Float(expected), new Float(actual));


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules
squid:S1244 - “Floating point numbers should not be tested for equality”. You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1244
And
squid:S1444 - “"public static" fields should be constant ”. You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1444
Please let me know if you have any questions.
Ayman Abdelghany.