### PR TITLE
Using Log instead of Throwable.printStackTrace(...)

### DIFF
--- a/benchmark/src/net/rubyeye/memcached/BaseReadWriteThread.java
+++ b/benchmark/src/net/rubyeye/memcached/BaseReadWriteThread.java
@@ -8,6 +8,7 @@ import net.rubyeye.memcached.benchmark.StringGenerator;
 
 public abstract class BaseReadWriteThread extends Thread {
 
+	private static final Logger log = LoggerFactory.getLogger(BaseReadWriteThread.class);
 	protected int repeats;
 	protected CyclicBarrier barrier;
 	protected int offset;
@@ -64,7 +65,7 @@ public abstract class BaseReadWriteThread extends Thread {
 
 			barrier.await();
 		} catch (Exception e) {
-			e.printStackTrace();
+			log.error(e.getMessage(), e);
 
 		}
 	}

--- a/benchmark/src/net/rubyeye/memcached/benchmark/result_analyse/ResultAnalyser.java
+++ b/benchmark/src/net/rubyeye/memcached/benchmark/result_analyse/ResultAnalyser.java
@@ -40,6 +40,7 @@ import org.jfree.data.general.DatasetUtilities;
  */
 public class ResultAnalyser {
 
+	private static final Logger log = LoggerFactory.getLogger(ResultAnalyser.class);
 	private static final int HEIGHT = 600;
 	private static final String DEFAULT_RESULT_IMAGES_DIR = "result/images";
 	private static final String DEFAULT_RESULT_DIR = "result";
@@ -251,15 +252,16 @@ public class ResultAnalyser {
 			ChartUtilities.writeChartAsJPEG(out, chart, weight, height);
 			out.flush();
 		} catch (FileNotFoundException e) {
-			e.printStackTrace();
+			log.error(e.getMessage(), e);
 		} catch (IOException e) {
-			e.printStackTrace();
+			log.error(e.getMessage(), e);
 		} finally {
 			if (out != null) {
 				try {
 					out.close();
 				} catch (IOException e) {
 					// do nothing
+					log.error(e.getMessage(), e);
 				}
 			}
 		}
@@ -285,8 +287,8 @@ public class ResultAnalyser {
 		render.setSeriesPaint(2, Color.YELLOW);
 		render.setSeriesPaint(3, Color.BLUE);
 		render.setSeriesPaint(4, Color.CYAN);
-		render.setShapesFilled(Boolean.TRUE);// ÔÚÊý¾ÝµãÏÔÊ¾ÊµÐÄµÄÐ¡Í¼±ê
-		render.setShapesVisible(true);// ÉèÖÃÏÔÊ¾Ð¡Í¼±ê
+		render.setShapesFilled(Boolean.TRUE);// ï¿½ï¿½ï¿½ï¿½ï¿½Ýµï¿½ï¿½ï¿½Ê¾Êµï¿½Äµï¿½Ð¡Í¼ï¿½ï¿½
+		render.setShapesVisible(true);// ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½Ê¾Ð¡Í¼ï¿½ï¿½
 
 		CategoryAxis cateaxis = plot.getDomainAxis();
 
@@ -305,7 +307,7 @@ public class ResultAnalyser {
 	}
 
 	/**
-	 * ´´½¨CategoryDataset¶ÔÏó
+	 * ï¿½ï¿½ï¿½ï¿½CategoryDatasetï¿½ï¿½ï¿½ï¿½
 	 * 
 	 */
 	public static CategoryDataset createDataset(String[] rowKeys,

--- a/src/test/java/com/google/code/yanf4j/test/unittest/core/impl/FutureImplUnitTest.java
+++ b/src/test/java/com/google/code/yanf4j/test/unittest/core/impl/FutureImplUnitTest.java
@@ -1,16 +1,16 @@
 package com.google.code.yanf4j.test.unittest.core.impl;
 
+import com.google.code.yanf4j.core.impl.FutureImpl;
+import junit.framework.Assert;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.io.IOException;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
-
-import junit.framework.Assert;
-
-import org.junit.Test;
-
-import com.google.code.yanf4j.core.impl.FutureImpl;
 
 
 /**
@@ -24,6 +24,8 @@ import com.google.code.yanf4j.core.impl.FutureImpl;
 
 public class FutureImplUnitTest {
 
+    private static final Logger log = LoggerFactory.getLogger(FutureImplUnitTest.class);
+    
     private static final class NotifyFutureRunner implements Runnable {
         FutureImpl<Boolean> future;
         long sleepTime;
@@ -105,7 +107,7 @@ public class FutureImplUnitTest {
                     future.cancel(true);
                 }
                 catch (Exception e) {
-                    e.printStackTrace();
+                    log.error(e.getMessage(), e);
                 }
             }
         }).start();

--- a/src/test/java/net/rubyeye/xmemcached/example/BinaryProtocolExample.java
+++ b/src/test/java/net/rubyeye/xmemcached/example/BinaryProtocolExample.java
@@ -9,6 +9,8 @@ import net.rubyeye.xmemcached.XMemcachedClientBuilder;
 import net.rubyeye.xmemcached.exception.MemcachedException;
 import net.rubyeye.xmemcached.utils.AddrUtil;
 import net.rubyeye.xmemcached.command.BinaryCommandFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Simple example for xmemcached,use binary protocol
@@ -17,6 +19,9 @@ import net.rubyeye.xmemcached.command.BinaryCommandFactory;
  * 
  */
 public class BinaryProtocolExample {
+
+	private static final Logger log = LoggerFactory.getLogger(BinaryProtocolExample.class);
+	
 	public static void main(String[] args) {
 		if (args.length < 1) {
 			System.err.println("Useage:java BinaryProtocolExample [servers]");
@@ -40,19 +45,17 @@ public class BinaryProtocolExample {
 			value = memcachedClient.get("a");
 			System.out.println("after delete,a=" + value);
 		} catch (MemcachedException e) {
-			System.err.println("MemcachedClient operation fail");
-			e.printStackTrace();
+			log.error("MemcachedClient operation fail", e);
 		} catch (TimeoutException e) {
-			System.err.println("MemcachedClient operation timeout");
-			e.printStackTrace();
+			log.error("MemcachedClient operation timeout", e);
 		} catch (InterruptedException e) {
 			// ignore
+			log.info(e.getMessage());
 		}
 		try {
 			memcachedClient.shutdown();
 		} catch (Exception e) {
-			System.err.println("Shutdown MemcachedClient fail");
-			e.printStackTrace();
+			log.error("Shutdown MemcachedClient fail", e);
 		}
 	}
 

--- a/src/test/java/net/rubyeye/xmemcached/example/CASExample.java
+++ b/src/test/java/net/rubyeye/xmemcached/example/CASExample.java
@@ -19,6 +19,8 @@ import net.rubyeye.xmemcached.MemcachedClientBuilder;
 import net.rubyeye.xmemcached.XMemcachedClientBuilder;
 import net.rubyeye.xmemcached.command.BinaryCommandFactory;
 import net.rubyeye.xmemcached.utils.AddrUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * CASOperation example
@@ -26,6 +28,10 @@ import net.rubyeye.xmemcached.utils.AddrUtil;
  * @author dennis
  */
 class CASThread extends Thread {
+
+
+	private static final Logger log = LoggerFactory.getLogger(CASThread.class);
+	
 	/**
 	 * Increase Operation
 	 * 
@@ -61,7 +67,7 @@ class CASThread extends Thread {
 					this.cd.countDown();
 				}
 		} catch (Exception e) {
-			e.printStackTrace();
+			log.error(e.getMessage(), e);
 		}
 	}
 }

--- a/src/test/java/net/rubyeye/xmemcached/example/MemcachedStateListenerExample.java
+++ b/src/test/java/net/rubyeye/xmemcached/example/MemcachedStateListenerExample.java
@@ -8,8 +8,12 @@ import net.rubyeye.xmemcached.MemcachedClientBuilder;
 import net.rubyeye.xmemcached.MemcachedClientStateListener;
 import net.rubyeye.xmemcached.XMemcachedClientBuilder;
 import net.rubyeye.xmemcached.utils.AddrUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 class MyListener implements MemcachedClientStateListener {
+
+	private static final Logger log = LoggerFactory.getLogger(MyListener.class);
 
 	public void onConnected(MemcachedClient memcachedClient,
 			InetSocketAddress inetSocketAddress) {
@@ -23,7 +27,7 @@ class MyListener implements MemcachedClientStateListener {
 	}
 
 	public void onException(MemcachedClient memcachedClient, Throwable throwable) {
-		throwable.printStackTrace();
+		log.error(throwable.getMessage(), throwable);
 
 	}
 
@@ -40,6 +44,9 @@ class MyListener implements MemcachedClientStateListener {
 }
 
 public class MemcachedStateListenerExample {
+
+	private static final Logger log = LoggerFactory.getLogger(MemcachedStateListenerExample.class);
+	
 	public static void main(String[] args) {
 		if (args.length < 1) {
 			System.err
@@ -50,7 +57,7 @@ public class MemcachedStateListenerExample {
 		try {
 			memcachedClient.shutdown();
 		} catch (IOException e) {
-			e.printStackTrace();
+			log.error(e.getMessage(), e);
 		}
 	}
 
@@ -64,7 +71,7 @@ public class MemcachedStateListenerExample {
 			return builder.build();
 		} catch (IOException e) {
 			System.err.println("Create MemcachedClient fail");
-			e.printStackTrace();
+			log.error(e.getMessage(), e);
 		}
 		return null;
 	}

--- a/src/test/java/net/rubyeye/xmemcached/example/SASLExample.java
+++ b/src/test/java/net/rubyeye/xmemcached/example/SASLExample.java
@@ -16,6 +16,8 @@ import net.rubyeye.xmemcached.exception.MemcachedException;
 import net.rubyeye.xmemcached.utils.AddrUtil;
 import net.rubyeye.xmemcached.auth.AuthInfo;
 import net.rubyeye.xmemcached.command.BinaryCommandFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Simple example for xmemcached,use binary protocol
@@ -24,6 +26,9 @@ import net.rubyeye.xmemcached.command.BinaryCommandFactory;
  * 
  */
 public class SASLExample {
+
+	private static final Logger log = LoggerFactory.getLogger(SASLExample.class);
+
 	public static void main(String[] args) {
 		if (args.length < 3) {
 			System.err
@@ -49,19 +54,16 @@ public class SASLExample {
 			value = memcachedClient.get("a");
 			System.out.println("after delete,a=" + value);
 		} catch (MemcachedException e) {
-			System.err.println("MemcachedClient operation fail");
-			e.printStackTrace();
+			log.error("MemcachedClient operation fail", e);
 		} catch (TimeoutException e) {
-			System.err.println("MemcachedClient operation timeout");
-			e.printStackTrace();
+			log.error("MemcachedClient operation timeout", e);
 		} catch (InterruptedException e) {
 			// ignore
 		}
 		try {
 			memcachedClient.shutdown();
 		} catch (Exception e) {
-			System.err.println("Shutdown MemcachedClient fail");
-			e.printStackTrace();
+			log.error("Shutdown MemcachedClient fail", e);
 		}
 	}
 
@@ -76,8 +78,7 @@ public class SASLExample {
 			builder.setCommandFactory(new BinaryCommandFactory());
 			return builder.build();
 		} catch (IOException e) {
-			System.err.println("Create MemcachedClient fail");
-			e.printStackTrace();
+			log.error("Create MemcachedClient fail", e);
 		}
 		return null;
 	}

--- a/src/test/java/net/rubyeye/xmemcached/example/SimpleExample.java
+++ b/src/test/java/net/rubyeye/xmemcached/example/SimpleExample.java
@@ -9,6 +9,8 @@ import net.rubyeye.xmemcached.MemcachedClientBuilder;
 import net.rubyeye.xmemcached.XMemcachedClientBuilder;
 import net.rubyeye.xmemcached.exception.MemcachedException;
 import net.rubyeye.xmemcached.utils.AddrUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Simple example for xmemcached
@@ -17,6 +19,9 @@ import net.rubyeye.xmemcached.utils.AddrUtil;
  * 
  */
 public class SimpleExample {
+
+	private static final Logger log = LoggerFactory.getLogger(SimpleExample.class);
+
 	public static void main(String[] args) {
 		if (args.length < 1) {
 			System.err.println("Useage:java SimpleExample [servers]");
@@ -53,19 +58,17 @@ public class SimpleExample {
 			System.out.println(memcachedClient.touch("b", 1000));
 
 		} catch (MemcachedException e) {
-			System.err.println("MemcachedClient operation fail");
-			e.printStackTrace();
+			log.error("MemcachedClient operation fail", e);
 		} catch (TimeoutException e) {
-			System.err.println("MemcachedClient operation timeout");
-			e.printStackTrace();
+			log.error("MemcachedClient operation timeout", e);
 		} catch (InterruptedException e) {
 			// ignore
+			log.info(e.getMessage());
 		}
 		try {
 			memcachedClient.shutdown();
 		} catch (Exception e) {
-			System.err.println("Shutdown MemcachedClient fail");
-			e.printStackTrace();
+			log.error("Shutdown MemcachedClient fail", e);
 		}
 	}
 
@@ -76,8 +79,7 @@ public class SimpleExample {
 					AddrUtil.getAddresses(servers));
 			return builder.build();
 		} catch (IOException e) {
-			System.err.println("Create MemcachedClient fail");
-			e.printStackTrace();
+			log.error("Create MemcachedClient fail", e);
 		}
 		return null;
 	}


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1148 - “ Throwable.printStackTrace(...) should not be called”. You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1148
Please let me know if you have any questions.
Ayman Abdelghany.