### PR TITLE
General clean up - continued

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,8 @@ jdk:
   - openjdk6
 services:
   - memcached
+script:
+  - mvn verify
 after_script:
   - '[ "${TRAVIS_PULL_REQUEST}" = "false" ] && travis_wait 300 mvn site -Ppublish-site-github || false'
 env:

--- a/pom.xml
+++ b/pom.xml
@@ -58,13 +58,20 @@
 	<properties>
 		<github.account>bmahe</github.account>
 
+		<!-- Default to number of CPUs on the host. See cpu-count goal of the build 
+			helper plugin -->
+		<surefire.thread.count>${cpu.count}</surefire.thread.count>
+		<surefire.perCoreThreadCount>false</surefire.perCoreThreadCount>
+
 		<maven.compiler.source>1.5</maven.compiler.source>
 		<maven.compiler.target>1.5</maven.compiler.target>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
+		<build.helper.maven.plugin.version>1.10</build.helper.maven.plugin.version>
 		<cobertura-maven-plugin>2.6</cobertura-maven-plugin>
 		<maven-checkstyle-plugin>2.10</maven-checkstyle-plugin>
 		<maven.dependency.plugin.version>2.10</maven.dependency.plugin.version>
+		<maven.failsafe.plugin.version>2.19.1</maven.failsafe.plugin.version>
 		<maven.findbugs.report.plugin>3.0.1</maven.findbugs.report.plugin>
 		<maven.jxr.plugin.version>2.1</maven.jxr.plugin.version>
 		<maven-pmd-plugin>3.0.1</maven-pmd-plugin>
@@ -80,7 +87,7 @@
 		<hibernate.memcached.version>1.2</hibernate.memcached.version>
 		<jta.version>1.1</jta.version>
 		<log4j.version>1.2.16</log4j.version>
-		<junit.version>4.4</junit.version>
+		<junit.version>4.12</junit.version>
 		<easymock.version>2.4</easymock.version>
 
 		<test.memcached.host>localhost</test.memcached.host>
@@ -109,6 +116,22 @@
 		</testResources>
 
 		<plugins>
+			<plugin>
+				<groupId>org.codehaus.mojo</groupId>
+				<artifactId>build-helper-maven-plugin</artifactId>
+				<version>${build.helper.maven.plugin.version}</version>
+				<executions>
+					<execution>
+						<id>get-cpu-count</id>
+						<goals>
+							<goal>cpu-count</goal>
+						</goals>
+						<configuration>
+							<cpuCount>cpu.count</cpuCount>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-javadoc-plugin</artifactId>
@@ -140,9 +163,27 @@
 				<version>${maven.surefire.plugin.version}</version>
 				<configuration>
 					<redirectTestOutputToFile>true</redirectTestOutputToFile>
+					<parallel>classes</parallel>
+					<perCoreThreadCount>${surefire.perCoreThreadCount}</perCoreThreadCount>
+					<threadCount>${surefire.thread.count}</threadCount>
 				</configuration>
 			</plugin>
-
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-failsafe-plugin</artifactId>
+				<version>${maven.failsafe.plugin.version}</version>
+				<executions>
+					<execution>
+						<goals>
+							<goal>integration-test</goal>
+							<goal>verify</goal>
+						</goals>
+					</execution>
+				</executions>
+				<configuration>
+					<redirectTestOutputToFile>true</redirectTestOutputToFile>
+				</configuration>
+			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-assembly-plugin</artifactId>
@@ -242,6 +283,14 @@
 				<configuration>
 					<showSuccess>false</showSuccess>
 				</configuration>
+				<reportSets>
+					<reportSet>
+						<reports>
+							<report>failsafe-report-only</report>
+							<report>report-only</report>
+						</reports>
+					</reportSet>
+				</reportSets>
 			</plugin>
 			<!-- Source code cross reference -->
 			<plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -186,6 +186,7 @@
 			<groupId>javax.transaction</groupId>
 			<artifactId>jta</artifactId>
 			<version>${jta.version}</version>
+			<scope>provided</scope>
 		</dependency>
 
 		<!-- Test dependencies -->

--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
 		<maven.compiler.target>1.5</maven.compiler.target>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-		<build.helper.maven.plugin.version>1.10</build.helper.maven.plugin.version>
+		<build.helper.maven.plugin.version>1.9.1</build.helper.maven.plugin.version>
 		<cobertura-maven-plugin>2.6</cobertura-maven-plugin>
 		<maven-checkstyle-plugin>2.10</maven-checkstyle-plugin>
 		<maven.dependency.plugin.version>2.10</maven.dependency.plugin.version>

--- a/src/main/java/com/google/code/yanf4j/core/impl/PoolDispatcher.java
+++ b/src/main/java/com/google/code/yanf4j/core/impl/PoolDispatcher.java
@@ -40,22 +40,24 @@ import com.google.code.yanf4j.util.WorkerThreadFactory;
  * 
  */
 public class PoolDispatcher implements Dispatcher {
-	public static final int POOL_QUEUE_SIZE_FACTOR = 1000;
-	public static final float MAX_POOL_SIZE_FACTOR = 1.25f;
+	public static final int DEFAULT_POOL_QUEUE_SIZE_FACTOR = 1000;
+	public static final float DEFAULT_MAX_POOL_SIZE_FACTOR = 1.25f;
 	private ThreadPoolExecutor threadPool;
 
 	public PoolDispatcher(int poolSize) {
-		this(poolSize, 60, TimeUnit.SECONDS,
-				new ThreadPoolExecutor.AbortPolicy(), "pool-dispatcher");
+		this(poolSize, 60, TimeUnit.SECONDS, new ThreadPoolExecutor.AbortPolicy(), "pool-dispatcher");
 	}
 
 	public PoolDispatcher(int poolSize, long keepAliveTime, TimeUnit unit,
 			RejectedExecutionHandler rejectedExecutionHandler, String prefix) {
-		this.threadPool = new ThreadPoolExecutor(poolSize,
-				(int) (MAX_POOL_SIZE_FACTOR * poolSize), keepAliveTime, unit,
-				new ArrayBlockingQueue<Runnable>(poolSize
-						* POOL_QUEUE_SIZE_FACTOR), new WorkerThreadFactory(
-						prefix));
+		this(poolSize, DEFAULT_POOL_QUEUE_SIZE_FACTOR, DEFAULT_MAX_POOL_SIZE_FACTOR, keepAliveTime, unit,
+				rejectedExecutionHandler, prefix);
+	}
+
+	public PoolDispatcher(int poolSize, int poolQueueSizeFactor, float maxPoolSizeFactor, long keepAliveTime,
+			TimeUnit unit, RejectedExecutionHandler rejectedExecutionHandler, String prefix) {
+		this.threadPool = new ThreadPoolExecutor(poolSize, (int) (maxPoolSizeFactor * poolSize), keepAliveTime, unit,
+				new ArrayBlockingQueue<Runnable>(poolSize * poolQueueSizeFactor), new WorkerThreadFactory(prefix));
 		this.threadPool.setRejectedExecutionHandler(rejectedExecutionHandler);
 	}
 

--- a/src/test/java/com/google/code/yanf4j/test/unittest/core/impl/TextLineCodecFactoryUnitTest.java
+++ b/src/test/java/com/google/code/yanf4j/test/unittest/core/impl/TextLineCodecFactoryUnitTest.java
@@ -8,7 +8,6 @@ import com.google.code.yanf4j.buffer.IoBuffer;
 import com.google.code.yanf4j.core.CodecFactory.Encoder;
 import com.google.code.yanf4j.core.impl.TextLineCodecFactory;
 
-
 /**
  * 
  * 
@@ -19,50 +18,46 @@ import com.google.code.yanf4j.core.impl.TextLineCodecFactory;
  */
 
 public class TextLineCodecFactoryUnitTest {
-    TextLineCodecFactory textLineCodecFactory;
+	TextLineCodecFactory textLineCodecFactory;
 
+	@Before
+	public void setUp() {
+		this.textLineCodecFactory = new TextLineCodecFactory();
+		TextLineCodecFactory.SPLIT.clear();
+	}
 
-    @Before
-    public void setUp() {
-        this.textLineCodecFactory = new TextLineCodecFactory();
-    }
+	@Test
+	public void testEncodeNormal() throws Exception {
+		Encoder encoder = this.textLineCodecFactory.getEncoder();
+		Assert.assertNotNull(encoder);
+		IoBuffer buffer = encoder.encode("hello", null);
+		Assert.assertNotNull(buffer);
+		Assert.assertTrue(buffer.hasRemaining());
+		Assert.assertArrayEquals("hello\r\n".getBytes("utf-8"), buffer.array());
 
+	}
 
-    @Test
-    public void testEncodeNormal() throws Exception {
-        Encoder encoder = this.textLineCodecFactory.getEncoder();
-        Assert.assertNotNull(encoder);
-        IoBuffer buffer = encoder.encode("hello", null);
-        Assert.assertNotNull(buffer);
-        Assert.assertTrue(buffer.hasRemaining());
-        Assert.assertArrayEquals("hello\r\n".getBytes("utf-8"), buffer.array());
+	@Test
+	public void testEncodeEmpty() throws Exception {
+		Encoder encoder = this.textLineCodecFactory.getEncoder();
+		Assert.assertNull(encoder.encode(null, null));
+		Assert.assertEquals(TextLineCodecFactory.SPLIT, encoder.encode("", null));
+	}
 
-    }
+	@Test
+	public void decodeNormal() throws Exception {
+		Encoder encoder = this.textLineCodecFactory.getEncoder();
+		Assert.assertNotNull(encoder);
+		IoBuffer buffer = encoder.encode("hello", null);
 
+		String str = (String) this.textLineCodecFactory.getDecoder().decode(buffer, null);
+		Assert.assertEquals("hello", str);
+	}
 
-    @Test
-    public void testEncodeEmpty() throws Exception {
-        Encoder encoder = this.textLineCodecFactory.getEncoder();
-        Assert.assertNull(encoder.encode(null, null));
-        Assert.assertEquals(TextLineCodecFactory.SPLIT, encoder.encode("", null));
-    }
-
-
-    @Test
-    public void decodeNormal() throws Exception {
-        Encoder encoder = this.textLineCodecFactory.getEncoder();
-        Assert.assertNotNull(encoder);
-        IoBuffer buffer = encoder.encode("hello", null);
-
-        String str = (String) this.textLineCodecFactory.getDecoder().decode(buffer, null);
-        Assert.assertEquals("hello", str);
-    }
-
-
-    @Test
-    public void decodeEmpty() throws Exception {
-        Assert.assertNull(this.textLineCodecFactory.getDecoder().decode(null, null));
-        Assert.assertEquals("", this.textLineCodecFactory.getDecoder().decode(TextLineCodecFactory.SPLIT, null));
-    }
+	@Test
+	public void decodeEmpty() throws Exception {
+		Assert.assertNull(this.textLineCodecFactory.getDecoder().decode(null, null));
+		Assert.assertEquals("", this.textLineCodecFactory.getDecoder().decode(TextLineCodecFactory.SPLIT, null));
+	}
 
 }

--- a/src/test/java/net/rubyeye/xmemcached/test/unittest/BinaryMemcachedClientIT.java
+++ b/src/test/java/net/rubyeye/xmemcached/test/unittest/BinaryMemcachedClientIT.java
@@ -23,7 +23,7 @@ import org.junit.Test;
  * @author boyan
  * 
  */
-public class BinaryMemcachedClientUnitTest extends XMemcachedClientTest {
+public class BinaryMemcachedClientIT extends XMemcachedClientIT {
 	@Override
 	public MemcachedClientBuilder createBuilder() throws Exception {
 

--- a/src/test/java/net/rubyeye/xmemcached/test/unittest/ConnectionPoolMemcachedClientIT.java
+++ b/src/test/java/net/rubyeye/xmemcached/test/unittest/ConnectionPoolMemcachedClientIT.java
@@ -16,7 +16,7 @@ import com.google.code.yanf4j.core.Session;
 import com.google.code.yanf4j.core.impl.HandlerAdapter;
 import com.google.code.yanf4j.nio.TCPController;
 
-public class ConnectionPoolMemcachedClientTest extends XMemcachedClientTest {
+public class ConnectionPoolMemcachedClientIT extends XMemcachedClientIT {
 	private static final int CONNECTION_POOL_SIZE = 3;
 
 	@Override

--- a/src/test/java/net/rubyeye/xmemcached/test/unittest/ConsistentHashMemcachedClientIT.java
+++ b/src/test/java/net/rubyeye/xmemcached/test/unittest/ConsistentHashMemcachedClientIT.java
@@ -8,7 +8,7 @@ import net.rubyeye.xmemcached.XMemcachedClientBuilder;
 import net.rubyeye.xmemcached.impl.KetamaMemcachedSessionLocator;
 import net.rubyeye.xmemcached.utils.AddrUtil;
 
-public class ConsistentHashMemcachedClientTest extends StandardHashMemcachedClientTest {
+public class ConsistentHashMemcachedClientIT extends StandardHashMemcachedClientIT {
 	@Override
 	public MemcachedClientBuilder createBuilder() throws Exception {
 		MemcachedClientBuilder builder = new XMemcachedClientBuilder(AddrUtil

--- a/src/test/java/net/rubyeye/xmemcached/test/unittest/KestrelClientIT.java
+++ b/src/test/java/net/rubyeye/xmemcached/test/unittest/KestrelClientIT.java
@@ -19,7 +19,7 @@ import net.rubyeye.xmemcached.utils.AddrUtil;
 
 import com.google.code.yanf4j.util.ResourcesUtils;
 
-public class KestrelClientUnitTest extends TestCase {
+public class KestrelClientIT extends TestCase {
 	static class UserDefinedClass implements Serializable {
 		private String name;
 
@@ -231,11 +231,11 @@ public class KestrelClientUnitTest extends TestCase {
 			try {
 				this.cyclicBarrier.await();
 				for (int i = 0; i < 10000; i++) {
-					KestrelClientUnitTest.this.memcachedClient.set("queue1", 0,
+					KestrelClientIT.this.memcachedClient.set("queue1", 0,
 							"hello");
 				}
 				for (int i = 0; i < 10000; i++) {
-					KestrelClientUnitTest.this.memcachedClient.get("queue1");
+					KestrelClientIT.this.memcachedClient.get("queue1");
 				}
 				this.cyclicBarrier.await();
 			} catch (Exception e) {

--- a/src/test/java/net/rubyeye/xmemcached/test/unittest/StandardHashMemcachedClientIT.java
+++ b/src/test/java/net/rubyeye/xmemcached/test/unittest/StandardHashMemcachedClientIT.java
@@ -13,7 +13,7 @@ import net.rubyeye.xmemcached.impl.KetamaMemcachedSessionLocator;
 import net.rubyeye.xmemcached.transcoders.StringTranscoder;
 import net.rubyeye.xmemcached.utils.AddrUtil;
 
-public class StandardHashMemcachedClientTest extends XMemcachedClientTest {
+public class StandardHashMemcachedClientIT extends XMemcachedClientIT {
 
 	@Override
 	public MemcachedClientBuilder createBuilder() throws Exception {

--- a/src/test/java/net/rubyeye/xmemcached/test/unittest/XMemcachedClientIT.java
+++ b/src/test/java/net/rubyeye/xmemcached/test/unittest/XMemcachedClientIT.java
@@ -54,7 +54,7 @@ import net.rubyeye.xmemcached.utils.Protocol;
 import com.google.code.yanf4j.buffer.IoBuffer;
 import com.google.code.yanf4j.util.ResourcesUtils;
 
-public abstract class XMemcachedClientTest extends TestCase {
+public abstract class XMemcachedClientIT extends TestCase {
 	protected MemcachedClient memcachedClient;
 	Properties properties;
 	private MockTranscoder mockTranscoder;

--- a/src/test/java/net/rubyeye/xmemcached/test/unittest/XMemcachedClientWithKeyProviderIT.java
+++ b/src/test/java/net/rubyeye/xmemcached/test/unittest/XMemcachedClientWithKeyProviderIT.java
@@ -1,5 +1,7 @@
 package net.rubyeye.xmemcached.test.unittest;
 
+import java.net.InetSocketAddress;
+import java.util.List;
 import java.util.concurrent.TimeoutException;
 
 import net.rubyeye.xmemcached.KeyProvider;
@@ -9,6 +11,7 @@ import net.rubyeye.xmemcached.MemcachedClientCallable;
 import net.rubyeye.xmemcached.XMemcachedClientBuilder;
 import net.rubyeye.xmemcached.command.BinaryCommandFactory;
 import net.rubyeye.xmemcached.exception.MemcachedException;
+import net.rubyeye.xmemcached.impl.KetamaMemcachedSessionLocator;
 import net.rubyeye.xmemcached.utils.AddrUtil;
 import net.rubyeye.xmemcached.utils.ByteUtils;
 
@@ -38,6 +41,24 @@ public class XMemcachedClientWithKeyProviderIT extends XMemcachedClientIT{
 		ByteUtils.testing = true;
 		return builder;
 	}
+	
+	@Override
+	public MemcachedClientBuilder createWeightedBuilder() throws Exception {
+		List<InetSocketAddress> addressList = AddrUtil
+				.getAddresses(this.properties
+						.getProperty("test.memcached.servers"));
+		int[] weights = new int[addressList.size()];
+		for (int i = 0; i < weights.length; i++) {
+			weights[i] = i + 1;
+		}
+
+		MemcachedClientBuilder builder = new XMemcachedClientBuilder(
+				addressList, weights);
+		builder.setCommandFactory(new BinaryCommandFactory());
+		ByteUtils.testing = true;
+		return builder;
+	}
+
 	
 	public void testKeyProvider(){
 		String process = keyProvider.process("namespace:a");

--- a/src/test/java/net/rubyeye/xmemcached/test/unittest/XMemcachedClientWithKeyProviderIT.java
+++ b/src/test/java/net/rubyeye/xmemcached/test/unittest/XMemcachedClientWithKeyProviderIT.java
@@ -12,7 +12,7 @@ import net.rubyeye.xmemcached.exception.MemcachedException;
 import net.rubyeye.xmemcached.utils.AddrUtil;
 import net.rubyeye.xmemcached.utils.ByteUtils;
 
-public class XMemcachedClientWithKeyProviderTest extends XMemcachedClientTest{
+public class XMemcachedClientWithKeyProviderIT extends XMemcachedClientIT{
 	
 	private KeyProvider keyProvider;
 	

--- a/src/test/java/net/rubyeye/xmemcached/test/unittest/hibernate/XmemcacheClientFactoryUnitIT.java
+++ b/src/test/java/net/rubyeye/xmemcached/test/unittest/hibernate/XmemcacheClientFactoryUnitIT.java
@@ -11,7 +11,7 @@ import com.googlecode.hibernate.memcached.Memcache;
 import com.googlecode.hibernate.memcached.PropertiesHelper;
 import com.googlecode.hibernate.memcached.spymemcached.SpyMemcacheClientFactory;
 
-public class XmemcacheClientFactoryUnitTest extends TestCase {
+public class XmemcacheClientFactoryUnitIT extends TestCase {
 	Properties properties;
 
 	@Override

--- a/src/test/java/net/rubyeye/xmemcached/test/unittest/impl/MemcachedClientStateListenerIT.java
+++ b/src/test/java/net/rubyeye/xmemcached/test/unittest/impl/MemcachedClientStateListenerIT.java
@@ -12,7 +12,7 @@ import net.rubyeye.xmemcached.XMemcachedClientBuilder;
 import net.rubyeye.xmemcached.utils.AddrUtil;
 import junit.framework.TestCase;
 
-public class MemcachedClientStateListenerUnitTest extends TestCase {
+public class MemcachedClientStateListenerIT extends TestCase {
 
 	MemcachedClient memcachedClient;
 	MockMemcachedClientStateListener listener;

--- a/src/test/java/net/rubyeye/xmemcached/test/unittest/utils/XMemcachedClientFactoryBeanIT.java
+++ b/src/test/java/net/rubyeye/xmemcached/test/unittest/utils/XMemcachedClientFactoryBeanIT.java
@@ -10,7 +10,7 @@ import net.rubyeye.xmemcached.exception.MemcachedException;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.support.ClassPathXmlApplicationContext;
 
-public class XMemcachedClientFactoryBeanUnitTest extends TestCase {
+public class XMemcachedClientFactoryBeanIT extends TestCase {
 
 	ApplicationContext ctx;
 

--- a/src/test/resources/applicationContext.xml
+++ b/src/test/resources/applicationContext.xml
@@ -1,9 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans"
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.5.xsd">
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:util="http://www.springframework.org/schema/util"
+	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.5.xsd
+	http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-2.5.xsd">
 	<bean id="propertyConfigurer"
-		class="org.springframework.beans.factory.config.PropertyPlaceholderConfigurer" destroy-method="shutdown">
+		class="org.springframework.beans.factory.config.PropertyPlaceholderConfigurer"
+		destroy-method="shutdown">
 		<property name="location">
 			<value>classpath:test.properties</value>
 		</property>
@@ -12,26 +14,27 @@
 		class="net.rubyeye.xmemcached.utils.XMemcachedClientFactoryBean">
 		<property name="servers">
 			<value>${test.memcached.servers}</value>
-			<!--<value>localhost:12000 localhost:12001</value>-->
+			<!--<value>localhost:12000 localhost:12001</value> -->
 		</property>
 	</bean>
 	<bean name="memcachedClient2"
-		class="net.rubyeye.xmemcached.utils.XMemcachedClientFactoryBean" destroy-method="shutdown">
+		class="net.rubyeye.xmemcached.utils.XMemcachedClientFactoryBean"
+		destroy-method="shutdown">
 		<property name="servers">
 			<value>${test.memcached.servers}</value>
 		</property>
 		<property name="weights">
-			<list>
+			<util:list value-type="java.lang.Integer">
 				<value>1</value>
 				<value>2</value>
 				<value>3</value>
 				<value>4</value>
 				<value>5</value>
-			</list>
+			</util:list>
 		</property>
 		<property name="connectionPoolSize" value="2"></property>
 		<property name="commandFactory">
-		   <bean class="net.rubyeye.xmemcached.command.BinaryCommandFactory"></bean>
+			<bean class="net.rubyeye.xmemcached.command.BinaryCommandFactory"></bean>
 		</property>
 		<property name="sessionLocator">
 			<bean class="net.rubyeye.xmemcached.impl.KetamaMemcachedSessionLocator"></bean>


### PR DESCRIPTION
* Separate unit tests from integration tests. Note: We may want to move integration tests in a different directory altogether at some point.
* Run unit tests in parallel. Time to run them on my machine went from 50s to 14s.
* Fix test TextLineCodecFactoryUnitTest::decodeNormal 
* Fix test XMemcachedClientFactoryBeanIT
* Fix test XMemcachedClientWithKeyProviderIT::testWeightedServers
* Specify final for some constants
* jta dependency should have a scope of provided to match hibernate-memecached scope
* Run integration tests in travis build