### PR TITLE
Remove duplicate MemcachedException on fetch0 method

### DIFF
--- a/src/main/java/net/rubyeye/xmemcached/XMemcachedClient.java
+++ b/src/main/java/net/rubyeye/xmemcached/XMemcachedClient.java
@@ -638,7 +638,7 @@ public class XMemcachedClient implements XMemcachedClientMBean, MemcachedClient 
 	private final <T> Object fetch0(final String key, final byte[] keyBytes,
 			final CommandType cmdType, final long timeout,
 			Transcoder<T> transcoder) throws InterruptedException,
-			TimeoutException, MemcachedException, MemcachedException {
+			TimeoutException, MemcachedException {
 		final Command command = this.commandFactory.createGetCommand(key,
 				keyBytes, cmdType, this.transcoder);
 		this.latchWait(command, timeout, this.sendCommand(command));


### PR DESCRIPTION
hi, my friend:

I find a small question in com.googlecode.xmemcached, the following method has two MemcachedException. 
```
 net.rubyeye.xmemcached.XMemcachedClient
@SuppressWarnings("unchecked")
private final <T> Object fetch0(final String key, final byte[] keyBytes,
        final CommandType cmdType, final long timeout,
        Transcoder<T> transcoder) throws InterruptedException,
        TimeoutException, MemcachedException, MemcachedException {
```

Maybe this is no effetc for use it. But when I user bytebuddy(A bytecode manipulation framework, like asm javasist) to monitor the application, 
I encountered a problem , in bytebuddy not allow one method has same exception. I have given a issue to bytebuddy  #https://github.com/raphw/byte-buddy/issues/347

I also hope com.googlecode.xmemcached can get optimized to obtain better development.
Thank you very much! 