### PR TITLE
Docker swarm and InetAddress.getLocalHost() method

### DIFF
--- a/src/main/java/net/rubyeye/xmemcached/monitor/XMemcachedMbeanServer.java
+++ b/src/main/java/net/rubyeye/xmemcached/monitor/XMemcachedMbeanServer.java
@@ -79,16 +79,16 @@ public final class XMemcachedMbeanServer {
 			return;
 		}
 		// 鍒涘缓MBServer
-		String hostName = null;
-		try {
-			InetAddress addr = InetAddress.getLocalHost();
-
-			hostName = addr.getHostName();
-		} catch (IOException e) {
-			log.error("Get HostName Error", e);
-			hostName = "localhost";
-		}
-		String host = System.getProperty("hostName", hostName);
+        String host = System.getProperty("hostName");
+        if (host == null){
+            try {
+                InetAddress addr = InetAddress.getLocalHost();
+                host = addr.getHostName();
+            } catch (IOException e) {
+                log.error("Get HostName Error", e);
+                host = "localhost";
+            }
+        }
 		try {
 			boolean enableJMX = Boolean.parseBoolean(System
 					.getProperty(Constants.XMEMCACHED_JMX_ENABLE, "false"));


### PR DESCRIPTION
InetAddress.getLocalHost() method does not work correctly with docker and produces noise in logs.

My suggestion to change the order of calls:
1. we are trying to get host value from system properties
2. try to invoke InetAddress.getLocalHost() if system properties not set