### PR TITLE
Fix authentication on IP change

### DIFF
--- a/src/main/java/net/rubyeye/xmemcached/MemcachedClient.java
+++ b/src/main/java/net/rubyeye/xmemcached/MemcachedClient.java
@@ -18,9 +18,9 @@ import net.rubyeye.xmemcached.utils.Protocol;
 
 /**
  * The memcached client's interface
- * 
+ *
  * @author dennis
- * 
+ *
  */
 public interface MemcachedClient {
 
@@ -45,7 +45,7 @@ public interface MemcachedClient {
 	public static final int DEFAULT_TCP_SEND_BUFF_SIZE = 32 * 1024;
 	/**
 	 * Disable nagle algorithm by default
-	 * 
+	 *
 	 */
 	public static final boolean DEFAULT_TCP_NO_DELAY = true;
 	/**
@@ -91,7 +91,7 @@ public interface MemcachedClient {
 	/**
 	 * Default max queued noreply operations number.It is calcuated dynamically
 	 * based on your jvm maximum memory.
-	 * 
+	 *
 	 * @since 1.3.8
 	 */
 	public static final int DEFAULT_MAX_QUEUED_NOPS = DYNAMIC_MAX_QUEUED_NOPS > MAX_QUEUED_NOPS
@@ -100,7 +100,7 @@ public interface MemcachedClient {
 
 	/**
 	 * Maximum number of timeout exception for close connection.
-	 * 
+	 *
 	 * @since 1.4.0
 	 */
 	public static final int DEFAULT_MAX_TIMEOUTEXCEPTION_THRESHOLD = 1000;
@@ -108,27 +108,27 @@ public interface MemcachedClient {
 	/**
 	 * Set the merge factor,this factor determins how many 'get' commands would
 	 * be merge to one multi-get command.default is 150
-	 * 
+	 *
 	 * @param mergeFactor
 	 */
 	public void setMergeFactor(final int mergeFactor);
 
 	/**
 	 * Get the connect timeout
-	 * 
+	 *
 	 */
 	public long getConnectTimeout();
 
 	/**
 	 * Set the connect timeout,default is 1 minutes
-	 * 
+	 *
 	 * @param connectTimeout
 	 */
 	public void setConnectTimeout(long connectTimeout);
 
 	/**
 	 * return the session manager
-	 * 
+	 *
 	 * @return
 	 */
 	public Connector getConnector();
@@ -137,7 +137,7 @@ public interface MemcachedClient {
 	 * Enable/Disable merge many get commands to one multi-get command.true is
 	 * to enable it,false is to disable it.Default is true.Recommend users to
 	 * enable it.
-	 * 
+	 *
 	 * @param optimizeGet
 	 */
 	public void setOptimizeGet(final boolean optimizeGet);
@@ -145,7 +145,7 @@ public interface MemcachedClient {
 	/**
 	 * Enable/Disable merge many command's buffers to one big buffer fit
 	 * socket's send buffer size.Default is true.Recommend true.
-	 * 
+	 *
 	 * @param optimizeMergeBuffer
 	 */
 	public void setOptimizeMergeBuffer(final boolean optimizeMergeBuffer);
@@ -158,7 +158,7 @@ public interface MemcachedClient {
 	/**
 	 * Aadd a memcached server,the thread call this method will be blocked until
 	 * the connecting operations completed(success or fail)
-	 * 
+	 *
 	 * @param server
 	 *            host string
 	 * @param port
@@ -170,7 +170,7 @@ public interface MemcachedClient {
 	/**
 	 * Add a memcached server,the thread call this method will be blocked until
 	 * the connecting operations completed(success or fail)
-	 * 
+	 *
 	 * @param inetSocketAddress
 	 *            memcached server's socket address
 	 */
@@ -180,7 +180,7 @@ public interface MemcachedClient {
 	/**
 	 * Add many memcached servers.You can call this method through JMX or
 	 * program
-	 * 
+	 *
 	 * @param host
 	 *            String like [host1]:[port1] [host2]:[port2] ...
 	 */
@@ -193,7 +193,7 @@ public interface MemcachedClient {
 
 	/**
 	 * Remove many memcached server
-	 * 
+	 *
 	 * @param host
 	 *            String like [host1]:[port1] [host2]:[port2] ...
 	 */
@@ -201,8 +201,8 @@ public interface MemcachedClient {
 
 	/**
 	 * Set the nio's ByteBuffer Allocator,use SimpleBufferAllocator by default.
-	 * 
-	 * 
+	 *
+	 *
 	 * @param bufferAllocator
 	 * @return
 	 */
@@ -211,7 +211,7 @@ public interface MemcachedClient {
 
 	/**
 	 * Get value by key
-	 * 
+	 *
 	 * @param <T>
 	 * @param key
 	 *            Key
@@ -241,14 +241,14 @@ public interface MemcachedClient {
 	/**
 	 * Just like get,But it return a GetsResponse,include cas value for cas
 	 * update.
-	 * 
+	 *
 	 * @param <T>
 	 * @param key
 	 *            key
 	 * @param timeout
 	 *            operation timeout
 	 * @param transcoder
-	 * 
+	 *
 	 * @return GetsResponse
 	 * @throws TimeoutException
 	 * @throws InterruptedException
@@ -300,7 +300,7 @@ public interface MemcachedClient {
 
 	/**
 	 * Bulk get items
-	 * 
+	 *
 	 * @param <T>
 	 * @param keyCollections
 	 *            key collection
@@ -359,7 +359,7 @@ public interface MemcachedClient {
 
 	/**
 	 * Bulk gets items
-	 * 
+	 *
 	 * @param <T>
 	 * @param keyCollections
 	 *            key collection
@@ -422,7 +422,7 @@ public interface MemcachedClient {
 
 	/**
 	 * Store key-value item to memcached
-	 * 
+	 *
 	 * @param <T>
 	 * @param key
 	 *            stored key
@@ -466,7 +466,7 @@ public interface MemcachedClient {
 
 	/**
 	 * Store key-value item to memcached,doesn't wait for reply
-	 * 
+	 *
 	 * @param <T>
 	 * @param key
 	 *            stored key
@@ -501,7 +501,7 @@ public interface MemcachedClient {
 	/**
 	 * Add key-value item to memcached, success only when the key is not exists
 	 * in memcached.
-	 * 
+	 *
 	 * @param <T>
 	 * @param key
 	 * @param exp
@@ -549,7 +549,7 @@ public interface MemcachedClient {
 
 	/**
 	 * @see #add(String, int, Object, Transcoder, long)
-	 * 
+	 *
 	 * @param <T>
 	 * @param key
 	 * @param exp
@@ -567,7 +567,7 @@ public interface MemcachedClient {
 	/**
 	 * Add key-value item to memcached, success only when the key is not exists
 	 * in memcached.This method doesn't wait for reply.
-	 * 
+	 *
 	 * @param <T>
 	 * @param key
 	 * @param exp
@@ -601,7 +601,7 @@ public interface MemcachedClient {
 	/**
 	 * Replace the key's data item in memcached,success only when the key's data
 	 * item is exists in memcached.This method will wait for reply from server.
-	 * 
+	 *
 	 * @param <T>
 	 * @param key
 	 * @param exp
@@ -667,7 +667,7 @@ public interface MemcachedClient {
 	 * Replace the key's data item in memcached,success only when the key's data
 	 * item is exists in memcached.This method doesn't wait for reply from
 	 * server.
-	 * 
+	 *
 	 * @param <T>
 	 * @param key
 	 * @param exp
@@ -710,7 +710,7 @@ public interface MemcachedClient {
 
 	/**
 	 * Append value to key's data item,this method will wait for reply
-	 * 
+	 *
 	 * @param key
 	 * @param value
 	 * @param timeout
@@ -725,7 +725,7 @@ public interface MemcachedClient {
 
 	/**
 	 * Append value to key's data item,this method doesn't wait for reply.
-	 * 
+	 *
 	 * @param key
 	 * @param value
 	 * @throws TimeoutException
@@ -750,7 +750,7 @@ public interface MemcachedClient {
 	/**
 	 * Prepend value to key's data item in memcached.This method doesn't wait
 	 * for reply.
-	 * 
+	 *
 	 * @param key
 	 * @param value
 	 * @return boolean result
@@ -765,7 +765,7 @@ public interface MemcachedClient {
 	/**
 	 * Prepend value to key's data item in memcached.This method doesn't wait
 	 * for reply.
-	 * 
+	 *
 	 * @param key
 	 * @param value
 	 * @return
@@ -794,7 +794,7 @@ public interface MemcachedClient {
 	/**
 	 * Cas is a check and set operation which means "store this data but only if
 	 * no one else has updated since I last fetched it."
-	 * 
+	 *
 	 * @param <T>
 	 * @param key
 	 * @param exp
@@ -849,7 +849,7 @@ public interface MemcachedClient {
 	/**
 	 * Cas is a check and set operation which means "store this data but only if
 	 * no one else has updated since I last fetched it."
-	 * 
+	 *
 	 * @param <T>
 	 * @param key
 	 * @param exp
@@ -871,7 +871,7 @@ public interface MemcachedClient {
 	/**
 	 * cas is a check and set operation which means "store this data but only if
 	 * no one else has updated since I last fetched it."
-	 * 
+	 *
 	 * @param <T>
 	 * @param key
 	 * @param exp
@@ -952,7 +952,7 @@ public interface MemcachedClient {
 			throws TimeoutException, InterruptedException, MemcachedException;
 
 	/**
-	 * 
+	 *
 	 * @param <T>
 	 * @param key
 	 * @param getsResponse
@@ -968,7 +968,7 @@ public interface MemcachedClient {
 
 	/**
 	 * cas noreply
-	 * 
+	 *
 	 * @param <T>
 	 * @param key
 	 * @param exp
@@ -1026,7 +1026,7 @@ public interface MemcachedClient {
 	 * <strong>Note: This method is deprecated,because memcached 1.4.0 remove
 	 * the optional argument "time".You can still use this method on old
 	 * version,but is not recommended.</strong>
-	 * 
+	 *
 	 * @param key
 	 * @param time
 	 * @throws InterruptedException
@@ -1038,7 +1038,7 @@ public interface MemcachedClient {
 
 	/**
 	 * Delete key's date item from memcached
-	 * 
+	 *
 	 * @param key
 	 * @param opTimeout
 	 *            Operation timeout
@@ -1054,7 +1054,7 @@ public interface MemcachedClient {
 	/**
 	 * Delete key's date item from memcached only if its cas value is the same
 	 * as what was read.
-	 * 
+	 *
 	 * @param key
 	 * @cas cas on delete to make sure the key is deleted only if its value is
 	 *      same as what was read.
@@ -1071,7 +1071,7 @@ public interface MemcachedClient {
 
 	/**
 	 * Set a new expiration time for an existing item
-	 * 
+	 *
 	 * @param key
 	 *            item's key
 	 * @param exp
@@ -1090,7 +1090,7 @@ public interface MemcachedClient {
 	/**
 	 * Set a new expiration time for an existing item,using default opTimeout
 	 * second.
-	 * 
+	 *
 	 * @param key
 	 *            item's key
 	 * @param exp
@@ -1106,7 +1106,7 @@ public interface MemcachedClient {
 
 	/**
 	 * Get item and set a new expiration time for it
-	 * 
+	 *
 	 * @param <T>
 	 * @param key
 	 *            item's key
@@ -1125,7 +1125,7 @@ public interface MemcachedClient {
 
 	/**
 	 * Get item and set a new expiration time for it,using default opTimeout
-	 * 
+	 *
 	 * @param <T>
 	 * @param key
 	 * @param newExp
@@ -1139,7 +1139,7 @@ public interface MemcachedClient {
 
 	/**
 	 * Bulk get items and touch them
-	 * 
+	 *
 	 * @param <T>
 	 * @param keyExpMap
 	 *            A map,key is item's key,and value is a new expiration time for
@@ -1157,7 +1157,7 @@ public interface MemcachedClient {
 
 	/**
 	 * Bulk get items and touch them,using default opTimeout
-	 * 
+	 *
 	 * @see #getAndTouch(Map, long)
 	 * @param <T>
 	 * @param keyExpMap
@@ -1171,7 +1171,7 @@ public interface MemcachedClient {
 
 	/**
 	 * Get all connected memcached servers's version.
-	 * 
+	 *
 	 * @return
 	 * @throws TimeoutException
 	 * @throws InterruptedException
@@ -1188,7 +1188,7 @@ public interface MemcachedClient {
 	 * item must already exist for incr to work; these commands won't pretend
 	 * that a non-existent key exists with value 0; instead, it will fail.This
 	 * method doesn't wait for reply.
-	 * 
+	 *
 	 * @return the new value of the item's data, after the increment operation
 	 *         was carried out.
 	 * @param key
@@ -1210,7 +1210,7 @@ public interface MemcachedClient {
 	 * item must already exist for incr to work; these commands won't pretend
 	 * that a non-existent key exists with value 0; instead, it will fail.This
 	 * method doesn't wait for reply.
-	 * 
+	 *
 	 * @param key
 	 *            key
 	 * @param num
@@ -1236,7 +1236,7 @@ public interface MemcachedClient {
 	 * item must already exist for decr to work; these commands won't pretend
 	 * that a non-existent key exists with value 0; instead, it will fail.This
 	 * method doesn't wait for reply.
-	 * 
+	 *
 	 * @return the new value of the item's data, after the decrement operation
 	 *         was carried out.
 	 * @param key
@@ -1268,7 +1268,7 @@ public interface MemcachedClient {
 	 * item must already exist for decr to work; these commands won't pretend
 	 * that a non-existent key exists with value 0; instead, it will fail.This
 	 * method doesn't wait for reply.
-	 * 
+	 *
 	 * @param key
 	 *            The key
 	 * @param num
@@ -1288,7 +1288,7 @@ public interface MemcachedClient {
 
 	/**
 	 * Make All connected memcached's data item invalid
-	 * 
+	 *
 	 * @throws TimeoutException
 	 * @throws InterruptedException
 	 * @throws MemcachedException
@@ -1301,7 +1301,7 @@ public interface MemcachedClient {
 
 	/**
 	 * Make All connected memcached's data item invalid
-	 * 
+	 *
 	 * @param timeout
 	 *            operation timeout
 	 * @throws TimeoutException
@@ -1313,7 +1313,7 @@ public interface MemcachedClient {
 
 	/**
 	 * Invalidate all existing items immediately
-	 * 
+	 *
 	 * @param address
 	 *            Target memcached server
 	 * @param timeout
@@ -1333,10 +1333,10 @@ public interface MemcachedClient {
 
 	/**
 	 * This method is deprecated,please use flushAll(InetSocketAddress) instead.
-	 * 
+	 *
 	 * @deprecated
 	 * @param host
-	 * 
+	 *
 	 * @throws TimeoutException
 	 * @throws InterruptedException
 	 * @throws MemcachedException
@@ -1350,7 +1350,7 @@ public interface MemcachedClient {
 
 	/**
 	 * �ョ��瑰������emcached server缁��淇℃�
-	 * 
+	 *
 	 * @param address
 	 *            ����板�
 	 * @param timeout
@@ -1365,7 +1365,7 @@ public interface MemcachedClient {
 
 	/**
 	 * Get stats from all memcached servers
-	 * 
+	 *
 	 * @param timeout
 	 * @return server->item->value map
 	 * @throws MemcachedException
@@ -1380,7 +1380,7 @@ public interface MemcachedClient {
 
 	/**
 	 * Get special item stats. "stats items" for example
-	 * 
+	 *
 	 * @param item
 	 * @return
 	 */
@@ -1395,7 +1395,7 @@ public interface MemcachedClient {
 
 	/**
 	 * return default transcoder,default is SerializingTranscoder
-	 * 
+	 *
 	 * @return
 	 */
 	@SuppressWarnings("unchecked")
@@ -1403,7 +1403,7 @@ public interface MemcachedClient {
 
 	/**
 	 * set transcoder
-	 * 
+	 *
 	 * @param transcoder
 	 */
 	@SuppressWarnings("unchecked")
@@ -1415,14 +1415,14 @@ public interface MemcachedClient {
 
 	/**
 	 * get operation timeout setting
-	 * 
+	 *
 	 * @return
 	 */
 	public long getOpTimeout();
 
 	/**
 	 * set operation timeout,default is one second.
-	 * 
+	 *
 	 * @param opTimeout
 	 */
 	public void setOpTimeout(long opTimeout);
@@ -1433,7 +1433,7 @@ public interface MemcachedClient {
 	/**
 	 * Returns available memcached servers list.This method is drepcated,please
 	 * use getAvailableServers instead.
-	 * 
+	 *
 	 * @see #getAvailableServers()
 	 * @return
 	 */
@@ -1442,14 +1442,14 @@ public interface MemcachedClient {
 
 	/**
 	 * Returns available memcached servers list.
-	 * 
+	 *
 	 * @return A available server collection
 	 */
 	public Collection<InetSocketAddress> getAvailableServers();
 
 	/**
 	 * add a memcached server to MemcachedClient
-	 * 
+	 *
 	 * @param server
 	 * @param port
 	 * @param weight
@@ -1469,7 +1469,7 @@ public interface MemcachedClient {
 	 * <strong>Note: This method is deprecated,because memcached 1.4.0 remove
 	 * the optional argument "time".You can still use this method on old
 	 * version,but is not recommended.</strong>
-	 * 
+	 *
 	 * @param key
 	 * @param time
 	 * @throws InterruptedException
@@ -1490,7 +1490,7 @@ public interface MemcachedClient {
 	 * item must already exist for incr to work; these commands won't pretend
 	 * that a non-existent key exists with value 0; instead, it will fail.This
 	 * method doesn't wait for reply.
-	 * 
+	 *
 	 * @param key
 	 * @param num
 	 * @throws InterruptedException
@@ -1507,7 +1507,7 @@ public interface MemcachedClient {
 	 * item must already exist for decr to work; these commands won't pretend
 	 * that a non-existent key exists with value 0; instead, it will fail.This
 	 * method doesn't wait for reply.
-	 * 
+	 *
 	 * @param key
 	 * @param num
 	 * @throws InterruptedException
@@ -1519,7 +1519,7 @@ public interface MemcachedClient {
 	/**
 	 * Set the verbosity level of the memcached's logging output.This method
 	 * will wait for reply.
-	 * 
+	 *
 	 * @param address
 	 * @param level
 	 *            logging level
@@ -1533,7 +1533,7 @@ public interface MemcachedClient {
 	/**
 	 * Set the verbosity level of the memcached's logging output.This method
 	 * doesn't wait for reply from server
-	 * 
+	 *
 	 * @param address
 	 *            memcached server address
 	 * @param level
@@ -1546,21 +1546,21 @@ public interface MemcachedClient {
 
 	/**
 	 * Add a memcached client listener
-	 * 
+	 *
 	 * @param listener
 	 */
 	public void addStateListener(MemcachedClientStateListener listener);
 
 	/**
 	 * Remove a memcached client listener
-	 * 
+	 *
 	 * @param listener
 	 */
 	public void removeStateListener(MemcachedClientStateListener listener);
 
 	/**
 	 * Get all current state listeners
-	 * 
+	 *
 	 * @return
 	 */
 	public Collection<MemcachedClientStateListener> getStateListeners();
@@ -1581,7 +1581,7 @@ public interface MemcachedClient {
 	 * If the memcached dump or network error cause connection closed,xmemcached
 	 * would try to heal the connection.The interval between reconnections is 2
 	 * seconds by default. You can change that value by this method.
-	 * 
+	 *
 	 * @param healConnectionInterval
 	 *            MILLISECONDS
 	 */
@@ -1593,7 +1593,7 @@ public interface MemcachedClient {
 	 * this method:<br/>
 	 * <code> client.setEnableHealSession(false); </code><br/>
 	 * The default value is true.
-	 * 
+	 *
 	 * @param enableHealSession
 	 * @since 1.3.9
 	 */
@@ -1601,7 +1601,7 @@ public interface MemcachedClient {
 
 	/**
 	 * Return the default heal session interval in milliseconds
-	 * 
+	 *
 	 * @return
 	 */
 	public long getHealSessionInterval();
@@ -1621,7 +1621,7 @@ public interface MemcachedClient {
 	 * more connections to one or more memcached servers,and these connections
 	 * share the same reactor and thread pools,it will reduce the cost of
 	 * system.
-	 * 
+	 *
 	 * @param poolSize
 	 *            pool size,default is one,every memcached has only one
 	 *            connection.
@@ -1630,7 +1630,7 @@ public interface MemcachedClient {
 
 	/**
 	 * Whether to enable heart beat
-	 * 
+	 *
 	 * @param enableHeartBeat
 	 *            if true,then enable heartbeat,true by default
 	 */
@@ -1638,7 +1638,7 @@ public interface MemcachedClient {
 
 	/**
 	 * Enables/disables sanitizing keys by URLEncoding.
-	 * 
+	 *
 	 * @param sanitizeKey
 	 *            if true, then URLEncode all keys
 	 */
@@ -1648,7 +1648,7 @@ public interface MemcachedClient {
 
 	/**
 	 * Get counter for key,and if the key's value is not set,then set it with 0.
-	 * 
+	 *
 	 * @param key
 	 * @return
 	 */
@@ -1657,7 +1657,7 @@ public interface MemcachedClient {
 	/**
 	 * Get counter for key,and if the key's value is not set,then set it with
 	 * initial value.
-	 * 
+	 *
 	 * @param key
 	 * @param initialValue
 	 * @return
@@ -1670,7 +1670,7 @@ public interface MemcachedClient {
 	 * 'stats cachedump" has length limitation,so iterator could not visit all
 	 * keys if you have many keys.Your application should not be dependent on
 	 * this feature.
-	 * 
+	 *
 	 * @deprecated memcached 1.6.x will remove cachedump stats command,so this
 	 *             method will be removed in the future
 	 * @param address
@@ -1682,7 +1682,7 @@ public interface MemcachedClient {
 
 	/**
 	 * Configure auth info
-	 * 
+	 *
 	 * @param map
 	 *            Auth info map,key is memcached server address,and value is the
 	 *            auth info for the key.
@@ -1691,7 +1691,7 @@ public interface MemcachedClient {
 
 	/**
 	 * return current all auth info
-	 * 
+	 *
 	 * @return Auth info map,key is memcached server address,and value is the
 	 *         auth info for the key.
 	 */
@@ -1705,7 +1705,7 @@ public interface MemcachedClient {
 	 * item must already exist for incr to work; these commands won't pretend
 	 * that a non-existent key exists with value 0; instead, it will fail.This
 	 * method doesn't wait for reply.
-	 * 
+	 *
 	 * @param key
 	 * @param delta
 	 * @param initValue
@@ -1731,7 +1731,7 @@ public interface MemcachedClient {
 	 * item must already exist for incr to work; these commands won't pretend
 	 * that a non-existent key exists with value 0; instead, it will fail.This
 	 * method doesn't wait for reply.
-	 * 
+	 *
 	 * @param key
 	 *            key
 	 * @param delta
@@ -1754,14 +1754,14 @@ public interface MemcachedClient {
 
 	/**
 	 * Return the cache instance name
-	 * 
+	 *
 	 * @return
 	 */
 	public String getName();
 
 	/**
 	 * Set cache instance name
-	 * 
+	 *
 	 * @param name
 	 */
 	public void setName(String name);
@@ -1769,7 +1769,7 @@ public interface MemcachedClient {
 	/**
 	 * Returns reconnecting task queue,the queue is thread-safe and 'weakly
 	 * consistent',but maybe you <strong>should not modify it</strong> at all.
-	 * 
+	 *
 	 * @return The reconnecting task queue,if the client has not been
 	 *         started,returns null.
 	 */
@@ -1782,7 +1782,7 @@ public interface MemcachedClient {
 	 * but marked as unavailable,and then further requests to this server will
 	 * be transformed to standby node if configured or throw an exception until
 	 * it comes back up.
-	 * 
+	 *
 	 * @param failureMode
 	 *            true is to configure client in failure mode.
 	 */
@@ -1790,7 +1790,7 @@ public interface MemcachedClient {
 
 	/**
 	 * Returns if client is in failure mode.
-	 * 
+	 *
 	 * @return
 	 */
 	public boolean isFailureMode();
@@ -1798,7 +1798,7 @@ public interface MemcachedClient {
 	/**
 	 * Set a key provider for pre-processing keys before sending them to
 	 * memcached.
-	 * 
+	 *
 	 * @since 1.3.8
 	 * @param keyProvider
 	 */
@@ -1806,7 +1806,7 @@ public interface MemcachedClient {
 
 	/**
 	 * Returns maximum number of timeout exception for closing connection.
-	 * 
+	 *
 	 * @return
 	 */
 	public int getTimeoutExceptionThreshold();
@@ -1814,7 +1814,7 @@ public interface MemcachedClient {
 	/**
 	 * Set maximum number of timeout exception for closing connection.You can
 	 * set it to be a large value to disable this feature.
-	 * 
+	 *
 	 * @see #DEFAULT_MAX_TIMEOUTEXCEPTION_THRESHOLD
 	 * @param timeoutExceptionThreshold
 	 */
@@ -1823,7 +1823,7 @@ public interface MemcachedClient {
 	/**
 	 * Invalidate all namespace under the namespace using the default operation
 	 * timeout.
-	 * 
+	 *
 	 * @since 1.4.2
 	 * @param ns
 	 *            the namespace
@@ -1836,7 +1836,7 @@ public interface MemcachedClient {
 
 	/**
 	 * Invalidate all items under the namespace.
-	 * 
+	 *
 	 * @since 1.4.2
 	 * @param ns
 	 *            the namespace
@@ -1852,7 +1852,7 @@ public interface MemcachedClient {
 	/**
 	 * Remove current namespace set for this memcached client.It must begin with
 	 * {@link #beginWithNamespace(String)} method.
-	 * 
+	 *
 	 * @see #beginWithNamespace(String)
 	 */
 	public void endWithNamespace();
@@ -1860,7 +1860,7 @@ public interface MemcachedClient {
 	/**
 	 * set current namespace for following operations with memcached client.It
 	 * must be ended with {@link #endWithNamespace()} method.For example:
-	 * 
+	 *
 	 * <pre>
 	 * memcachedClient.beginWithNamespace(userId);
 	 * try {
@@ -1870,7 +1870,7 @@ public interface MemcachedClient {
 	 * 	memcachedClient.endWithNamespace();
 	 * }
 	 * </pre>
-	 * 
+	 *
 	 * @see #endWithNamespace()
 	 * @see #withNamespace(String, MemcachedClientCallable)
 	 * @param ns
@@ -1883,7 +1883,7 @@ public interface MemcachedClient {
 	 * namespace. {@link #beginWithNamespace(String)} and
 	 * {@link #endWithNamespace()} will called around automatically. For
 	 * example:
-	 * 
+	 *
 	 * <pre>
 	 *   memcachedClient.withNamespace(userId,new MemcachedClientCallable<Void>{
 	 *     public Void call(MemcachedClient client) throws MemcachedException,
@@ -1896,7 +1896,7 @@ public interface MemcachedClient {
 	 *   //invalidate all items under the namespace.
 	 *   memcachedClient.invalidateNamespace(userId);
 	 * </pre>
-	 * 
+	 *
 	 * @since 1.4.2
 	 * @param ns
 	 * @param callable

--- a/src/main/java/net/rubyeye/xmemcached/MemcachedClient.java
+++ b/src/main/java/net/rubyeye/xmemcached/MemcachedClient.java
@@ -1698,6 +1698,13 @@ public interface MemcachedClient {
 	public Map<InetSocketAddress, AuthInfo> getAuthInfoMap();
 
 	/**
+	 * Retruns the AuthInfo for all server strings (hostname:port)
+	 *
+	 * @return A map of AuthInfos for server strings (hostname:port)
+	 */
+	public Map<String, AuthInfo> getAuthInfoStringMap();
+
+	/**
 	 * "incr" are used to change data for some item in-place, incrementing it.
 	 * The data for the item is treated as decimal representation of a 64-bit
 	 * unsigned integer. If the current data value does not conform to such a

--- a/src/main/java/net/rubyeye/xmemcached/XMemcachedClient.java
+++ b/src/main/java/net/rubyeye/xmemcached/XMemcachedClient.java
@@ -104,6 +104,7 @@ public class XMemcachedClient
 	protected final AtomicInteger serverOrderCount = new AtomicInteger();
 
 	private Map<InetSocketAddress, AuthInfo> authInfoMap = new HashMap<InetSocketAddress, AuthInfo>();
+	private Map<String, AuthInfo> authInfoStringMap = new HashMap<String, AuthInfo>();
 
 	private String name; // cache name
 
@@ -274,6 +275,15 @@ public class XMemcachedClient
 
 	public void setAuthInfoMap(Map<InetSocketAddress, AuthInfo> map) {
 		this.authInfoMap = map;
+		this.authInfoStringMap = new HashMap<String, AuthInfo>();
+		for (Map.Entry<InetSocketAddress,AuthInfo> entry : map.entrySet()) {
+			String server = AddrUtil.getServerString(entry.getKey());
+			this.authInfoStringMap.put(server, entry.getValue());
+		}
+	}
+
+	public Map<String, AuthInfo> getAuthInfoStringMap() {
+		return this.authInfoStringMap;
 	}
 
 	/*

--- a/src/main/java/net/rubyeye/xmemcached/XMemcachedClient.java
+++ b/src/main/java/net/rubyeye/xmemcached/XMemcachedClient.java
@@ -77,9 +77,9 @@ import com.google.code.yanf4j.util.SystemUtils;
 
 /**
  * Memcached Client for connecting to memcached server and do operations.
- * 
+ *
  * @author dennis(killme2008@gmail.com)
- * 
+ *
  */
 public class XMemcachedClient
 		implements
@@ -125,7 +125,7 @@ public class XMemcachedClient
 
 	/*
 	 * (non-Javadoc)
-	 * 
+	 *
 	 * @see net.rubyeye.xmemcached.MemcachedClient#setMergeFactor(int)
 	 */
 	public final void setMergeFactor(final int mergeFactor) {
@@ -205,7 +205,7 @@ public class XMemcachedClient
 
 	/*
 	 * (non-Javadoc)
-	 * 
+	 *
 	 * @see net.rubyeye.xmemcached.MemcachedClient#getConnectTimeout()
 	 */
 	public long getConnectTimeout() {
@@ -214,7 +214,7 @@ public class XMemcachedClient
 
 	/*
 	 * (non-Javadoc)
-	 * 
+	 *
 	 * @see net.rubyeye.xmemcached.MemcachedClient#setConnectTimeout(long)
 	 */
 	public void setConnectTimeout(long connectTimeout) {
@@ -230,7 +230,7 @@ public class XMemcachedClient
 
 	/**
 	 * get operation timeout setting
-	 * 
+	 *
 	 * @return
 	 */
 	public final long getOpTimeout() {
@@ -239,7 +239,7 @@ public class XMemcachedClient
 
 	/**
 	 * set operation timeout,default is one second.
-	 * 
+	 *
 	 * @param opTimeout
 	 */
 	public final void setOpTimeout(long opTimeout) {
@@ -278,7 +278,7 @@ public class XMemcachedClient
 
 	/*
 	 * (non-Javadoc)
-	 * 
+	 *
 	 * @see net.rubyeye.xmemcached.MemcachedClient#getConnector()
 	 */
 	public final Connector getConnector() {
@@ -287,7 +287,7 @@ public class XMemcachedClient
 
 	/*
 	 * (non-Javadoc)
-	 * 
+	 *
 	 * @see
 	 * net.rubyeye.xmemcached.MemcachedClient#setOptimizeMergeBuffer(boolean)
 	 */
@@ -298,7 +298,7 @@ public class XMemcachedClient
 
 	/*
 	 * (non-Javadoc)
-	 * 
+	 *
 	 * @see net.rubyeye.xmemcached.MemcachedClient#isShutdown()
 	 */
 	public final boolean isShutdown() {
@@ -324,7 +324,7 @@ public class XMemcachedClient
 
 	/**
 	 * XMemcached constructor,default weight is 1
-	 * 
+	 *
 	 * @param server
 	 *            �����P
 	 * @param port
@@ -338,7 +338,7 @@ public class XMemcachedClient
 
 	/**
 	 * XMemcached constructor
-	 * 
+	 *
 	 * @param host
 	 *            server host
 	 * @param port
@@ -381,7 +381,7 @@ public class XMemcachedClient
 
 	/*
 	 * (non-Javadoc)
-	 * 
+	 *
 	 * @see net.rubyeye.xmemcached.MemcachedClient#addServer(java.lang.String,
 	 * int)
 	 */
@@ -392,7 +392,7 @@ public class XMemcachedClient
 
 	/**
 	 * add a memcached server to MemcachedClient
-	 * 
+	 *
 	 * @param server
 	 * @param port
 	 * @param weight
@@ -411,7 +411,7 @@ public class XMemcachedClient
 
 	/*
 	 * (non-Javadoc)
-	 * 
+	 *
 	 * @see net.rubyeye.xmemcached.MemcachedClient#addServer(java.net.
 	 * InetSocketAddress )
 	 */
@@ -434,7 +434,7 @@ public class XMemcachedClient
 
 	/*
 	 * (non-Javadoc)
-	 * 
+	 *
 	 * @see net.rubyeye.xmemcached.MemcachedClient#addServer(java.lang.String)
 	 */
 	public final void addServer(String hostList) throws IOException {
@@ -489,7 +489,7 @@ public class XMemcachedClient
 
 	/*
 	 * (non-Javadoc)
-	 * 
+	 *
 	 * @see net.rubyeye.xmemcached.MemcachedClient#getServersDescription()
 	 */
 	public final List<String> getServersDescription() {
@@ -522,7 +522,7 @@ public class XMemcachedClient
 
 	/*
 	 * (non-Javadoc)
-	 * 
+	 *
 	 * @see
 	 * net.rubyeye.xmemcached.MemcachedClient#removeServer(java.lang.String)
 	 */
@@ -693,7 +693,7 @@ public class XMemcachedClient
 
 	/**
 	 * Set max queued noreply operations number
-	 * 
+	 *
 	 * @param maxQueuedNoReplyOperations
 	 */
 	void setMaxQueuedNoReplyOperations(int maxQueuedNoReplyOperations) {
@@ -779,7 +779,7 @@ public class XMemcachedClient
 
 	/*
 	 * (non-Javadoc)
-	 * 
+	 *
 	 * @see
 	 * net.rubyeye.xmemcached.MemcachedClient#setBufferAllocator(net.rubyeye
 	 * .xmemcached.buffer.BufferAllocator)
@@ -791,7 +791,7 @@ public class XMemcachedClient
 
 	/**
 	 * XMemcached Constructor.
-	 * 
+	 *
 	 * @param inetSocketAddress
 	 * @param weight
 	 * @throws IOException
@@ -843,7 +843,7 @@ public class XMemcachedClient
 	 * XMemcachedClient constructor.Every server's weight is one by default. You
 	 * should not new client instance by this method, use MemcachedClientBuilder
 	 * instead.
-	 * 
+	 *
 	 * @param locator
 	 * @param allocator
 	 * @param conf
@@ -897,7 +897,7 @@ public class XMemcachedClient
 
 	/**
 	 * XMemcachedClient constructor.
-	 * 
+	 *
 	 * @param locator
 	 * @param allocator
 	 * @param conf
@@ -996,7 +996,7 @@ public class XMemcachedClient
 
 	/**
 	 * XMemcached Constructor.Every server's weight is one by default.
-	 * 
+	 *
 	 * @param addressList
 	 * @throws IOException
 	 */
@@ -1007,7 +1007,7 @@ public class XMemcachedClient
 
 	/**
 	 * XMemcached Constructor.Every server's weight is one by default.
-	 * 
+	 *
 	 * @param cmdFactory
 	 *            command factory
 	 * @param addressList
@@ -1039,7 +1039,7 @@ public class XMemcachedClient
 
 	/*
 	 * (non-Javadoc)
-	 * 
+	 *
 	 * @see net.rubyeye.xmemcached.MemcachedClient#get(java.lang.String, long,
 	 * net.rubyeye.xmemcached.transcoders.Transcoder)
 	 */
@@ -1052,7 +1052,7 @@ public class XMemcachedClient
 
 	/*
 	 * (non-Javadoc)
-	 * 
+	 *
 	 * @see net.rubyeye.xmemcached.MemcachedClient#get(java.lang.String, long)
 	 */
 	@SuppressWarnings("unchecked")
@@ -1063,7 +1063,7 @@ public class XMemcachedClient
 
 	/*
 	 * (non-Javadoc)
-	 * 
+	 *
 	 * @see net.rubyeye.xmemcached.MemcachedClient#get(java.lang.String,
 	 * net.rubyeye.xmemcached.transcoders.Transcoder)
 	 */
@@ -1074,7 +1074,7 @@ public class XMemcachedClient
 
 	/*
 	 * (non-Javadoc)
-	 * 
+	 *
 	 * @see net.rubyeye.xmemcached.MemcachedClient#get(java.lang.String)
 	 */
 	@SuppressWarnings("unchecked")
@@ -1094,7 +1094,7 @@ public class XMemcachedClient
 
 	/*
 	 * (non-Javadoc)
-	 * 
+	 *
 	 * @see net.rubyeye.xmemcached.MemcachedClient#gets(java.lang.String, long,
 	 * net.rubyeye.xmemcached.transcoders.Transcoder)
 	 */
@@ -1108,7 +1108,7 @@ public class XMemcachedClient
 
 	/*
 	 * (non-Javadoc)
-	 * 
+	 *
 	 * @see net.rubyeye.xmemcached.MemcachedClient#gets(java.lang.String)
 	 */
 	public final <T> GetsResponse<T> gets(final String key)
@@ -1118,7 +1118,7 @@ public class XMemcachedClient
 
 	/*
 	 * (non-Javadoc)
-	 * 
+	 *
 	 * @see net.rubyeye.xmemcached.MemcachedClient#gets(java.lang.String, long)
 	 */
 	@SuppressWarnings("unchecked")
@@ -1129,7 +1129,7 @@ public class XMemcachedClient
 
 	/*
 	 * (non-Javadoc)
-	 * 
+	 *
 	 * @see net.rubyeye.xmemcached.MemcachedClient#gets(java.lang.String,
 	 * net.rubyeye.xmemcached.transcoders.Transcoder)
 	 */
@@ -1142,7 +1142,7 @@ public class XMemcachedClient
 
 	/*
 	 * (non-Javadoc)
-	 * 
+	 *
 	 * @see net.rubyeye.xmemcached.MemcachedClient#get(java.util.Collection,
 	 * long, net.rubyeye.xmemcached.transcoders.Transcoder)
 	 */
@@ -1155,7 +1155,7 @@ public class XMemcachedClient
 
 	/*
 	 * (non-Javadoc)
-	 * 
+	 *
 	 * @see net.rubyeye.xmemcached.MemcachedClient#get(java.util.Collection,
 	 * net.rubyeye.xmemcached.transcoders.Transcoder)
 	 */
@@ -1168,7 +1168,7 @@ public class XMemcachedClient
 
 	/*
 	 * (non-Javadoc)
-	 * 
+	 *
 	 * @see net.rubyeye.xmemcached.MemcachedClient#get(java.util.Collection)
 	 */
 	public final <T> Map<String, T> get(final Collection<String> keyCollections)
@@ -1178,7 +1178,7 @@ public class XMemcachedClient
 
 	/*
 	 * (non-Javadoc)
-	 * 
+	 *
 	 * @see net.rubyeye.xmemcached.MemcachedClient#get(java.util.Collection,
 	 * long)
 	 */
@@ -1191,7 +1191,7 @@ public class XMemcachedClient
 
 	/*
 	 * (non-Javadoc)
-	 * 
+	 *
 	 * @see net.rubyeye.xmemcached.MemcachedClient#gets(java.util.Collection,
 	 * long, net.rubyeye.xmemcached.transcoders.Transcoder)
 	 */
@@ -1206,7 +1206,7 @@ public class XMemcachedClient
 
 	/*
 	 * (non-Javadoc)
-	 * 
+	 *
 	 * @see net.rubyeye.xmemcached.MemcachedClient#gets(java.util.Collection)
 	 */
 	public final <T> Map<String, GetsResponse<T>> gets(
@@ -1217,7 +1217,7 @@ public class XMemcachedClient
 
 	/*
 	 * (non-Javadoc)
-	 * 
+	 *
 	 * @see net.rubyeye.xmemcached.MemcachedClient#gets(java.util.Collection,
 	 * long)
 	 */
@@ -1230,7 +1230,7 @@ public class XMemcachedClient
 
 	/*
 	 * (non-Javadoc)
-	 * 
+	 *
 	 * @see net.rubyeye.xmemcached.MemcachedClient#gets(java.util.Collection,
 	 * net.rubyeye.xmemcached.transcoders.Transcoder)
 	 */
@@ -1323,7 +1323,7 @@ public class XMemcachedClient
 
 	/**
 	 * Hash key to servers
-	 * 
+	 *
 	 * @param keyCollections
 	 * @return
 	 */
@@ -1357,7 +1357,7 @@ public class XMemcachedClient
 
 	/*
 	 * (non-Javadoc)
-	 * 
+	 *
 	 * @see net.rubyeye.xmemcached.MemcachedClient#set(java.lang.String, int, T,
 	 * net.rubyeye.xmemcached.transcoders.Transcoder, long)
 	 */
@@ -1405,7 +1405,7 @@ public class XMemcachedClient
 
 	/*
 	 * (non-Javadoc)
-	 * 
+	 *
 	 * @see net.rubyeye.xmemcached.MemcachedClient#set(java.lang.String, int,
 	 * java.lang.Object)
 	 */
@@ -1417,7 +1417,7 @@ public class XMemcachedClient
 
 	/*
 	 * (non-Javadoc)
-	 * 
+	 *
 	 * @see net.rubyeye.xmemcached.MemcachedClient#set(java.lang.String, int,
 	 * java.lang.Object, long)
 	 */
@@ -1430,7 +1430,7 @@ public class XMemcachedClient
 
 	/*
 	 * (non-Javadoc)
-	 * 
+	 *
 	 * @see net.rubyeye.xmemcached.MemcachedClient#set(java.lang.String, int, T,
 	 * net.rubyeye.xmemcached.transcoders.Transcoder)
 	 */
@@ -1442,7 +1442,7 @@ public class XMemcachedClient
 
 	/*
 	 * (non-Javadoc)
-	 * 
+	 *
 	 * @see net.rubyeye.xmemcached.MemcachedClient#add(java.lang.String, int, T,
 	 * net.rubyeye.xmemcached.transcoders.Transcoder, long)
 	 */
@@ -1463,7 +1463,7 @@ public class XMemcachedClient
 
 	/*
 	 * (non-Javadoc)
-	 * 
+	 *
 	 * @see net.rubyeye.xmemcached.MemcachedClient#add(java.lang.String, int,
 	 * java.lang.Object)
 	 */
@@ -1475,7 +1475,7 @@ public class XMemcachedClient
 
 	/*
 	 * (non-Javadoc)
-	 * 
+	 *
 	 * @see net.rubyeye.xmemcached.MemcachedClient#add(java.lang.String, int,
 	 * java.lang.Object, long)
 	 */
@@ -1488,7 +1488,7 @@ public class XMemcachedClient
 
 	/*
 	 * (non-Javadoc)
-	 * 
+	 *
 	 * @see net.rubyeye.xmemcached.MemcachedClient#add(java.lang.String, int, T,
 	 * net.rubyeye.xmemcached.transcoders.Transcoder)
 	 */
@@ -1542,7 +1542,7 @@ public class XMemcachedClient
 
 	/*
 	 * (non-Javadoc)
-	 * 
+	 *
 	 * @see net.rubyeye.xmemcached.MemcachedClient#replace(java.lang.String,
 	 * int, T, net.rubyeye.xmemcached.transcoders.Transcoder, long)
 	 */
@@ -1557,7 +1557,7 @@ public class XMemcachedClient
 
 	/*
 	 * (non-Javadoc)
-	 * 
+	 *
 	 * @see net.rubyeye.xmemcached.MemcachedClient#replace(java.lang.String,
 	 * int, java.lang.Object)
 	 */
@@ -1569,7 +1569,7 @@ public class XMemcachedClient
 
 	/*
 	 * (non-Javadoc)
-	 * 
+	 *
 	 * @see net.rubyeye.xmemcached.MemcachedClient#replace(java.lang.String,
 	 * int, java.lang.Object, long)
 	 */
@@ -1582,7 +1582,7 @@ public class XMemcachedClient
 
 	/*
 	 * (non-Javadoc)
-	 * 
+	 *
 	 * @see net.rubyeye.xmemcached.MemcachedClient#replace(java.lang.String,
 	 * int, T, net.rubyeye.xmemcached.transcoders.Transcoder)
 	 */
@@ -1594,7 +1594,7 @@ public class XMemcachedClient
 
 	/*
 	 * (non-Javadoc)
-	 * 
+	 *
 	 * @see net.rubyeye.xmemcached.MemcachedClient#append(java.lang.String,
 	 * java.lang.Object)
 	 */
@@ -1605,7 +1605,7 @@ public class XMemcachedClient
 
 	/*
 	 * (non-Javadoc)
-	 * 
+	 *
 	 * @see net.rubyeye.xmemcached.MemcachedClient#append(java.lang.String,
 	 * java.lang.Object, long)
 	 */
@@ -1633,7 +1633,7 @@ public class XMemcachedClient
 
 	/*
 	 * (non-Javadoc)
-	 * 
+	 *
 	 * @see net.rubyeye.xmemcached.MemcachedClient#prepend(java.lang.String,
 	 * java.lang.Object)
 	 */
@@ -1644,7 +1644,7 @@ public class XMemcachedClient
 
 	/*
 	 * (non-Javadoc)
-	 * 
+	 *
 	 * @see net.rubyeye.xmemcached.MemcachedClient#prepend(java.lang.String,
 	 * java.lang.Object, long)
 	 */
@@ -1671,7 +1671,7 @@ public class XMemcachedClient
 
 	/*
 	 * (non-Javadoc)
-	 * 
+	 *
 	 * @see net.rubyeye.xmemcached.MemcachedClient#cas(java.lang.String, int,
 	 * java.lang.Object, long)
 	 */
@@ -1683,7 +1683,7 @@ public class XMemcachedClient
 
 	/*
 	 * (non-Javadoc)
-	 * 
+	 *
 	 * @see net.rubyeye.xmemcached.MemcachedClient#cas(java.lang.String, int, T,
 	 * net.rubyeye.xmemcached.transcoders.Transcoder, long, long)
 	 */
@@ -1698,7 +1698,7 @@ public class XMemcachedClient
 
 	/*
 	 * (non-Javadoc)
-	 * 
+	 *
 	 * @see net.rubyeye.xmemcached.MemcachedClient#cas(java.lang.String, int,
 	 * java.lang.Object, long, long)
 	 */
@@ -1711,7 +1711,7 @@ public class XMemcachedClient
 
 	/*
 	 * (non-Javadoc)
-	 * 
+	 *
 	 * @see net.rubyeye.xmemcached.MemcachedClient#cas(java.lang.String, int, T,
 	 * net.rubyeye.xmemcached.transcoders.Transcoder, long)
 	 */
@@ -1763,7 +1763,7 @@ public class XMemcachedClient
 
 	/*
 	 * (non-Javadoc)
-	 * 
+	 *
 	 * @see net.rubyeye.xmemcached.MemcachedClient#cas(java.lang.String, int,
 	 * net.rubyeye.xmemcached.CASOperation,
 	 * net.rubyeye.xmemcached.transcoders.Transcoder)
@@ -1781,7 +1781,7 @@ public class XMemcachedClient
 
 	/*
 	 * (non-Javadoc)
-	 * 
+	 *
 	 * @see net.rubyeye.xmemcached.MemcachedClient#cas(java.lang.String, int,
 	 * net.rubyeye.xmemcached.GetsResponse, net.rubyeye.xmemcached.CASOperation,
 	 * net.rubyeye.xmemcached.transcoders.Transcoder)
@@ -1799,7 +1799,7 @@ public class XMemcachedClient
 
 	/*
 	 * (non-Javadoc)
-	 * 
+	 *
 	 * @see net.rubyeye.xmemcached.MemcachedClient#cas(java.lang.String, int,
 	 * net.rubyeye.xmemcached.GetsResponse, net.rubyeye.xmemcached.CASOperation)
 	 */
@@ -1848,7 +1848,7 @@ public class XMemcachedClient
 
 	/*
 	 * (non-Javadoc)
-	 * 
+	 *
 	 * @see net.rubyeye.xmemcached.MemcachedClient#cas(java.lang.String,
 	 * net.rubyeye.xmemcached.GetsResponse, net.rubyeye.xmemcached.CASOperation)
 	 */
@@ -1860,7 +1860,7 @@ public class XMemcachedClient
 
 	/*
 	 * (non-Javadoc)
-	 * 
+	 *
 	 * @see net.rubyeye.xmemcached.MemcachedClient#cas(java.lang.String, int,
 	 * net.rubyeye.xmemcached.CASOperation)
 	 */
@@ -1873,7 +1873,7 @@ public class XMemcachedClient
 
 	/*
 	 * (non-Javadoc)
-	 * 
+	 *
 	 * @see net.rubyeye.xmemcached.MemcachedClient#cas(java.lang.String,
 	 * net.rubyeye.xmemcached.CASOperation)
 	 */
@@ -1885,7 +1885,7 @@ public class XMemcachedClient
 
 	/*
 	 * (non-Javadoc)
-	 * 
+	 *
 	 * @see net.rubyeye.xmemcached.MemcachedClient#delete(java.lang.String, int)
 	 */
 	public final boolean delete(final String key, final int time)
@@ -1905,7 +1905,7 @@ public class XMemcachedClient
 
 	/**
 	 * Delete key's data item from memcached.This method doesn't wait for reply
-	 * 
+	 *
 	 * @param key
 	 * @param time
 	 * @throws InterruptedException
@@ -2009,7 +2009,7 @@ public class XMemcachedClient
 
 	/*
 	 * (non-Javadoc)
-	 * 
+	 *
 	 * @see net.rubyeye.xmemcached.MemcachedClient#incr(java.lang.String, int)
 	 */
 	public final long incr(String key, final long delta)
@@ -2065,7 +2065,7 @@ public class XMemcachedClient
 
 	/*
 	 * (non-Javadoc)
-	 * 
+	 *
 	 * @see net.rubyeye.xmemcached.MemcachedClient#decr(java.lang.String, int)
 	 */
 	public final long decr(String key, final long delta)
@@ -2099,7 +2099,7 @@ public class XMemcachedClient
 
 	/*
 	 * (non-Javadoc)
-	 * 
+	 *
 	 * @see net.rubyeye.xmemcached.MemcachedClient#flushAll()
 	 */
 	public final void flushAll()
@@ -2151,7 +2151,7 @@ public class XMemcachedClient
 
 	/*
 	 * (non-Javadoc)
-	 * 
+	 *
 	 * @see net.rubyeye.xmemcached.MemcachedClient#flushAll(long)
 	 */
 	public final void flushAll(long timeout)
@@ -2228,7 +2228,7 @@ public class XMemcachedClient
 
 	/*
 	 * (non-Javadoc)
-	 * 
+	 *
 	 * @see net.rubyeye.xmemcached.MemcachedClient#flushAll(java.net.
 	 * InetSocketAddress )
 	 */
@@ -2239,7 +2239,7 @@ public class XMemcachedClient
 
 	/*
 	 * (non-Javadoc)
-	 * 
+	 *
 	 * @see net.rubyeye.xmemcached.MemcachedClient#flushAll(java.net.
 	 * InetSocketAddress , long)
 	 */
@@ -2280,7 +2280,7 @@ public class XMemcachedClient
 
 	/*
 	 * (non-Javadoc)
-	 * 
+	 *
 	 * @see net.rubyeye.xmemcached.MemcachedClient#flushAll(java.lang.String)
 	 */
 	public final void flushAll(String host)
@@ -2290,7 +2290,7 @@ public class XMemcachedClient
 
 	/*
 	 * (non-Javadoc)
-	 * 
+	 *
 	 * @see
 	 * net.rubyeye.xmemcached.MemcachedClient#stats(java.net.InetSocketAddress)
 	 */
@@ -2301,7 +2301,7 @@ public class XMemcachedClient
 
 	/*
 	 * (non-Javadoc)
-	 * 
+	 *
 	 * @see
 	 * net.rubyeye.xmemcached.MemcachedClient#stats(java.net.InetSocketAddress,
 	 * long)
@@ -2424,7 +2424,7 @@ public class XMemcachedClient
 
 	/*
 	 * (non-Javadoc)
-	 * 
+	 *
 	 * @see net.rubyeye.xmemcached.MemcachedClient#shutdown()
 	 */
 	public final void shutdown() throws IOException {
@@ -2502,7 +2502,7 @@ public class XMemcachedClient
 
 	/*
 	 * (non-Javadoc)
-	 * 
+	 *
 	 * @see net.rubyeye.xmemcached.MemcachedClient#delete(java.lang.String)
 	 */
 	public final boolean delete(final String key)
@@ -2512,7 +2512,7 @@ public class XMemcachedClient
 
 	/*
 	 * (non-Javadoc)
-	 * 
+	 *
 	 * @see net.rubyeye.xmemcached.MemcachedClient#getTranscoder()
 	 */
 	@SuppressWarnings("unchecked")
@@ -2522,7 +2522,7 @@ public class XMemcachedClient
 
 	/*
 	 * (non-Javadoc)
-	 * 
+	 *
 	 * @see net.rubyeye.xmemcached.MemcachedClient#setTranscoder(net.rubyeye.
 	 * xmemcached .transcoders.Transcoder)
 	 */
@@ -2596,7 +2596,7 @@ public class XMemcachedClient
 
 	/**
 	 * Use getAvailableServers() instead
-	 * 
+	 *
 	 * @deprecated
 	 * @see MemcachedClient#getAvailableServers()
 	 */
@@ -2722,7 +2722,7 @@ public class XMemcachedClient
 
 	/**
 	 * Returns the real namespace of ns.
-	 * 
+	 *
 	 * @param ns
 	 * @return
 	 * @throws TimeoutException

--- a/src/main/java/net/rubyeye/xmemcached/XMemcachedClientBuilder.java
+++ b/src/main/java/net/rubyeye/xmemcached/XMemcachedClientBuilder.java
@@ -29,9 +29,9 @@ import com.google.code.yanf4j.core.impl.StandardSocketOption;
 
 /**
  * Builder pattern.Configure XmemcachedClient's options,then build it
- * 
+ *
  * @author dennis
- * 
+ *
  */
 public class XMemcachedClientBuilder implements MemcachedClientBuilder {
 
@@ -105,7 +105,7 @@ public class XMemcachedClientBuilder implements MemcachedClientBuilder {
 
 	/**
 	 * Set max queued noreply operations number
-	 * 
+	 *
 	 * @see MemcachedClient#DEFAULT_MAX_QUEUED_NOPS
 	 * @param maxQueuedNoReplyOperations
 	 * @since 1.3.8
@@ -260,7 +260,7 @@ public class XMemcachedClientBuilder implements MemcachedClientBuilder {
 
 	/*
 	 * (non-Javadoc)
-	 * 
+	 *
 	 * @see net.rubyeye.xmemcached.MemcachedClientBuilder#getSessionLocator()
 	 */
 	public MemcachedSessionLocator getSessionLocator() {
@@ -269,7 +269,7 @@ public class XMemcachedClientBuilder implements MemcachedClientBuilder {
 
 	/*
 	 * (non-Javadoc)
-	 * 
+	 *
 	 * @see net.rubyeye.xmemcached.MemcachedClientBuilder#setSessionLocator(net.
 	 * rubyeye .xmemcached.MemcachedSessionLocator)
 	 */
@@ -282,7 +282,7 @@ public class XMemcachedClientBuilder implements MemcachedClientBuilder {
 
 	/*
 	 * (non-Javadoc)
-	 * 
+	 *
 	 * @see net.rubyeye.xmemcached.MemcachedClientBuilder#getBufferAllocator()
 	 */
 	public BufferAllocator getBufferAllocator() {
@@ -291,7 +291,7 @@ public class XMemcachedClientBuilder implements MemcachedClientBuilder {
 
 	/*
 	 * (non-Javadoc)
-	 * 
+	 *
 	 * @see
 	 * net.rubyeye.xmemcached.MemcachedClientBuilder#setBufferAllocator(net.
 	 * rubyeye.xmemcached.buffer.BufferAllocator)
@@ -305,7 +305,7 @@ public class XMemcachedClientBuilder implements MemcachedClientBuilder {
 
 	/*
 	 * (non-Javadoc)
-	 * 
+	 *
 	 * @see net.rubyeye.xmemcached.MemcachedClientBuilder#getConfiguration()
 	 */
 	public Configuration getConfiguration() {
@@ -314,7 +314,7 @@ public class XMemcachedClientBuilder implements MemcachedClientBuilder {
 
 	/*
 	 * (non-Javadoc)
-	 * 
+	 *
 	 * @see
 	 * net.rubyeye.xmemcached.MemcachedClientBuilder#setConfiguration(com.google
 	 * .code.yanf4j.config.Configuration)
@@ -325,7 +325,7 @@ public class XMemcachedClientBuilder implements MemcachedClientBuilder {
 
 	/*
 	 * (non-Javadoc)
-	 * 
+	 *
 	 * @see net.rubyeye.xmemcached.MemcachedClientBuilder#build()
 	 */
 	public MemcachedClient build() throws IOException {
@@ -385,7 +385,7 @@ public class XMemcachedClientBuilder implements MemcachedClientBuilder {
 
 	/*
 	 * (non-Javadoc)
-	 * 
+	 *
 	 * @see
 	 * net.rubyeye.xmemcached.MemcachedClientBuilder#setTranscoder(transcoder)
 	 */
@@ -402,7 +402,7 @@ public class XMemcachedClientBuilder implements MemcachedClientBuilder {
 
 	/*
 	 * (non-Javadoc)
-	 * 
+	 *
 	 * @see net.rubyeye.xmemcached.MemcachedClientBuilder#setKeyProvider()
 	 */
 	public void setKeyProvider(KeyProvider keyProvider) {
@@ -413,7 +413,7 @@ public class XMemcachedClientBuilder implements MemcachedClientBuilder {
 
 	/*
 	 * (non-Javadoc)
-	 * 
+	 *
 	 * @see net.rubyeye.xmemcached.MemcachedClientBuilder#addAuthInfo()
 	 */
 	public void addAuthInfo(InetSocketAddress address, AuthInfo authInfo) {
@@ -434,7 +434,7 @@ public class XMemcachedClientBuilder implements MemcachedClientBuilder {
 
 	/*
 	 * (non-Javadoc)
-	 * 
+	 *
 	 * @see net.rubyeye.xmemcached.MemcachedClientBuilder#setName()
 	 */
 	public void setName(String name) {

--- a/src/main/java/net/rubyeye/xmemcached/auth/AuthMemcachedConnectListener.java
+++ b/src/main/java/net/rubyeye/xmemcached/auth/AuthMemcachedConnectListener.java
@@ -8,6 +8,7 @@ import net.rubyeye.xmemcached.XMemcachedClient;
 import net.rubyeye.xmemcached.impl.MemcachedTCPSession;
 import net.rubyeye.xmemcached.networking.MemcachedSession;
 import net.rubyeye.xmemcached.networking.MemcachedSessionConnectListener;
+import net.rubyeye.xmemcached.utils.AddrUtil;
 
 /**
  * Client state listener for auth
@@ -21,10 +22,10 @@ public class AuthMemcachedConnectListener
 
 	public void onConnect(MemcachedSession session, MemcachedClient client) {
 		MemcachedTCPSession tcpSession = (MemcachedTCPSession) session;
-		Map<InetSocketAddress, AuthInfo> authInfoMap = client.getAuthInfoMap();
+		Map<String, AuthInfo> authInfoMap = client.getAuthInfoStringMap();
 		if (authInfoMap != null) {
 			AuthInfo authInfo = authInfoMap
-					.get(tcpSession.getRemoteSocketAddress());
+					.get(AddrUtil.getServerString(tcpSession.getRemoteSocketAddress()));
 			if (authInfo != null) {
 				XMemcachedClient xMemcachedClient = (XMemcachedClient) client;
 				AuthTask task = new AuthTask(authInfo,

--- a/src/main/java/net/rubyeye/xmemcached/auth/AuthMemcachedConnectListener.java
+++ b/src/main/java/net/rubyeye/xmemcached/auth/AuthMemcachedConnectListener.java
@@ -11,9 +11,9 @@ import net.rubyeye.xmemcached.networking.MemcachedSessionConnectListener;
 
 /**
  * Client state listener for auth
- * 
+ *
  * @author dennis
- * 
+ *
  */
 public class AuthMemcachedConnectListener
 		implements

--- a/src/main/java/net/rubyeye/xmemcached/utils/AddrUtil.java
+++ b/src/main/java/net/rubyeye/xmemcached/utils/AddrUtil.java
@@ -1,12 +1,12 @@
 /**
  *Copyright [2009-2010] [dennis zhuang(killme2008@gmail.com)]
  *Licensed under the Apache License, Version 2.0 (the "License");
- *you may not use this file except in compliance with the License. 
- *You may obtain a copy of the License at 
- *             http://www.apache.org/licenses/LICENSE-2.0 
- *Unless required by applicable law or agreed to in writing, 
- *software distributed under the License is distributed on an "AS IS" BASIS, 
- *WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, 
+ *you may not use this file except in compliance with the License.
+ *You may obtain a copy of the License at
+ *             http://www.apache.org/licenses/LICENSE-2.0
+ *Unless required by applicable law or agreed to in writing,
+ *software distributed under the License is distributed on an "AS IS" BASIS,
+ *WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
  *either express or implied. See the License for the specific language governing permissions and limitations under the License
  */
 /**
@@ -40,7 +40,7 @@ public class AddrUtil {
 	 * suitable for instantiating a MemcachedClient,map's key is the main
 	 * memcached node,and value is the standby node for main node. Note that
 	 * colon-delimited IPv6 is also supported. For example: ::1:11211
-	 * 
+	 *
 	 * @param s
 	 * @return
 	 */
@@ -96,7 +96,7 @@ public class AddrUtil {
 	/**
 	 * Split a string in the form of "host:port host2:port" into a List of
 	 * InetSocketAddress instances suitable for instantiating a MemcachedClient.
-	 * 
+	 *
 	 * Note that colon-delimited IPv6 is also supported. For example: ::1:11211
 	 */
 	public static List<InetSocketAddress> getAddresses(String s) {
@@ -149,7 +149,7 @@ public class AddrUtil {
 
 	/**
 	 * System property to control shutdown hook, issue #44
-	 * 
+	 *
 	 * @since 2.0.1
 	 */
 	public static boolean isEnableShutDownHook() {

--- a/src/main/java/net/rubyeye/xmemcached/utils/AddrUtil.java
+++ b/src/main/java/net/rubyeye/xmemcached/utils/AddrUtil.java
@@ -156,4 +156,12 @@ public class AddrUtil {
 		return Boolean.valueOf(
 				System.getProperty("xmemcached.shutdown.hook.enable", "false"));
 	}
+
+	/**
+	 * Create an unresolved server string (hostname:port) from an InetSocketAddress.
+	 */
+	public static final String getServerString(InetSocketAddress addr) {
+		return addr.getHostString() + ":" + Integer.toString(addr.getPort());
+	}
+
 }


### PR DESCRIPTION
This fixes #68

The problem was the the `AuthInfoMap` stores an `AuthInfo` for a server's `InetSocketAddress`. Unfortunately, the `InetSocketAddress` hash is based on the resolved IP which can change. For this reason I changed the `AuthInfoMap` to store the `AuthInfo` based on the servers (hostname:port) string.

Note, I tried to fix this problem without changing any public interface but I don't like it. I could also change the `MemcachedClient.getAuthInfoMap()` from `public Map<InetSocketAddress, AuthInfo> getAuthInfoMap();` to `public Map<String, AuthInfo> getAuthInfoMap();` instead. This would be a bit nicer but change the interface. What do you think?

Review by commit. The first commit only removes trailing whitespaces. The code changes are all in the second commit.