### PR TITLE
Fix authentication on IP change

### DIFF
--- a/src/main/java/net/rubyeye/xmemcached/MemcachedClient.java
+++ b/src/main/java/net/rubyeye/xmemcached/MemcachedClient.java
@@ -17,9 +17,9 @@ import net.rubyeye.xmemcached.utils.Protocol;
 
 /**
  * The memcached client's interface
- * 
+ *
  * @author dennis
- * 
+ *
  */
 public interface MemcachedClient {
 
@@ -44,7 +44,7 @@ public interface MemcachedClient {
   public static final int DEFAULT_TCP_SEND_BUFF_SIZE = 32 * 1024;
   /**
    * Disable nagle algorithm by default
-   * 
+   *
    */
   public static final boolean DEFAULT_TCP_NO_DELAY = true;
   /**
@@ -87,7 +87,7 @@ public interface MemcachedClient {
   /**
    * Default max queued noreply operations number.It is calcuated dynamically based on your jvm
    * maximum memory.
-   * 
+   *
    * @since 1.3.8
    */
   public static final int DEFAULT_MAX_QUEUED_NOPS =
@@ -95,7 +95,7 @@ public interface MemcachedClient {
 
   /**
    * Maximum number of timeout exception for close connection.
-   * 
+   *
    * @since 1.4.0
    */
   public static final int DEFAULT_MAX_TIMEOUTEXCEPTION_THRESHOLD = 1000;
@@ -103,27 +103,27 @@ public interface MemcachedClient {
   /**
    * Set the merge factor,this factor determins how many 'get' commands would be merge to one
    * multi-get command.default is 150
-   * 
+   *
    * @param mergeFactor
    */
   public void setMergeFactor(final int mergeFactor);
 
   /**
    * Get the connect timeout
-   * 
+   *
    */
   public long getConnectTimeout();
 
   /**
    * Set the connect timeout,default is 1 minutes
-   * 
+   *
    * @param connectTimeout
    */
   public void setConnectTimeout(long connectTimeout);
 
   /**
    * return the session manager
-   * 
+   *
    * @return
    */
   public Connector getConnector();
@@ -131,7 +131,7 @@ public interface MemcachedClient {
   /**
    * Enable/Disable merge many get commands to one multi-get command.true is to enable it,false is
    * to disable it.Default is true.Recommend users to enable it.
-   * 
+   *
    * @param optimizeGet
    */
   public void setOptimizeGet(final boolean optimizeGet);
@@ -139,7 +139,7 @@ public interface MemcachedClient {
   /**
    * Enable/Disable merge many command's buffers to one big buffer fit socket's send buffer
    * size.Default is true.Recommend true.
-   * 
+   *
    * @param optimizeMergeBuffer
    */
   public void setOptimizeMergeBuffer(final boolean optimizeMergeBuffer);
@@ -152,7 +152,7 @@ public interface MemcachedClient {
   /**
    * Aadd a memcached server,the thread call this method will be blocked until the connecting
    * operations completed(success or fail)
-   * 
+   *
    * @param server host string
    * @param port port number
    */
@@ -161,14 +161,14 @@ public interface MemcachedClient {
   /**
    * Add a memcached server,the thread call this method will be blocked until the connecting
    * operations completed(success or fail)
-   * 
+   *
    * @param inetSocketAddress memcached server's socket address
    */
   public void addServer(final InetSocketAddress inetSocketAddress) throws IOException;
 
   /**
    * Add many memcached servers.You can call this method through JMX or program
-   * 
+   *
    * @param host String like [host1]:[port1] [host2]:[port2] ...
    */
   public void addServer(String hostList) throws IOException;
@@ -180,15 +180,15 @@ public interface MemcachedClient {
 
   /**
    * Remove many memcached server
-   * 
+   *
    * @param host String like [host1]:[port1] [host2]:[port2] ...
    */
   public void removeServer(String hostList);
 
   /**
    * Set the nio's ByteBuffer Allocator,use SimpleBufferAllocator by default.
-   * 
-   * 
+   *
+   *
    * @param bufferAllocator
    * @return
    */
@@ -197,7 +197,7 @@ public interface MemcachedClient {
 
   /**
    * Get value by key
-   * 
+   *
    * @param <T>
    * @param key Key
    * @param timeout Operation timeout,if the method is not returned in this time,throw
@@ -222,12 +222,12 @@ public interface MemcachedClient {
 
   /**
    * Just like get,But it return a GetsResponse,include cas value for cas update.
-   * 
+   *
    * @param <T>
    * @param key key
    * @param timeout operation timeout
    * @param transcoder
-   * 
+   *
    * @return GetsResponse
    * @throws TimeoutException
    * @throws InterruptedException
@@ -278,7 +278,7 @@ public interface MemcachedClient {
 
   /**
    * Bulk get items
-   * 
+   *
    * @param <T>
    * @param keyCollections key collection
    * @param opTimeout opTimeout
@@ -333,7 +333,7 @@ public interface MemcachedClient {
 
   /**
    * Bulk gets items
-   * 
+   *
    * @param <T>
    * @param keyCollections key collection
    * @param opTime Operation timeout
@@ -389,7 +389,7 @@ public interface MemcachedClient {
 
   /**
    * Store key-value item to memcached
-   * 
+   *
    * @param <T>
    * @param key stored key
    * @param exp An expiration time, in seconds. Can be up to 30 days. After 30 days, is treated as a
@@ -427,7 +427,7 @@ public interface MemcachedClient {
 
   /**
    * Store key-value item to memcached,doesn't wait for reply
-   * 
+   *
    * @param <T>
    * @param key stored key
    * @param exp An expiration time, in seconds. Can be up to 30 days. After 30 days, is treated as a
@@ -456,7 +456,7 @@ public interface MemcachedClient {
 
   /**
    * Add key-value item to memcached, success only when the key is not exists in memcached.
-   * 
+   *
    * @param <T>
    * @param key
    * @param exp An expiration time, in seconds. Can be up to 30 days. After 30 days, is treated as a
@@ -502,7 +502,7 @@ public interface MemcachedClient {
 
   /**
    * @see #add(String, int, Object, Transcoder, long)
-   * 
+   *
    * @param <T>
    * @param key
    * @param exp
@@ -520,7 +520,7 @@ public interface MemcachedClient {
   /**
    * Add key-value item to memcached, success only when the key is not exists in memcached.This
    * method doesn't wait for reply.
-   * 
+   *
    * @param <T>
    * @param key
    * @param exp An expiration time, in seconds. Can be up to 30 days. After 30 days, is treated as a
@@ -552,7 +552,7 @@ public interface MemcachedClient {
   /**
    * Replace the key's data item in memcached,success only when the key's data item is exists in
    * memcached.This method will wait for reply from server.
-   * 
+   *
    * @param <T>
    * @param key
    * @param exp An expiration time, in seconds. Can be up to 30 days. After 30 days, is treated as a
@@ -615,7 +615,7 @@ public interface MemcachedClient {
   /**
    * Replace the key's data item in memcached,success only when the key's data item is exists in
    * memcached.This method doesn't wait for reply from server.
-   * 
+   *
    * @param <T>
    * @param key
    * @param exp An expiration time, in seconds. Can be up to 30 days. After 30 days, is treated as a
@@ -656,7 +656,7 @@ public interface MemcachedClient {
 
   /**
    * Append value to key's data item,this method will wait for reply
-   * 
+   *
    * @param key
    * @param value
    * @param timeout
@@ -670,7 +670,7 @@ public interface MemcachedClient {
 
   /**
    * Append value to key's data item,this method doesn't wait for reply.
-   * 
+   *
    * @param key
    * @param value
    * @throws TimeoutException
@@ -694,7 +694,7 @@ public interface MemcachedClient {
 
   /**
    * Prepend value to key's data item in memcached.This method doesn't wait for reply.
-   * 
+   *
    * @param key
    * @param value
    * @return boolean result
@@ -707,7 +707,7 @@ public interface MemcachedClient {
 
   /**
    * Prepend value to key's data item in memcached.This method doesn't wait for reply.
-   * 
+   *
    * @param key
    * @param value
    * @return
@@ -735,7 +735,7 @@ public interface MemcachedClient {
   /**
    * Cas is a check and set operation which means "store this data but only if no one else has
    * updated since I last fetched it."
-   * 
+   *
    * @param <T>
    * @param key
    * @param exp An expiration time, in seconds. Can be up to 30 days. After 30 days, is treated as a
@@ -788,7 +788,7 @@ public interface MemcachedClient {
   /**
    * Cas is a check and set operation which means "store this data but only if no one else has
    * updated since I last fetched it."
-   * 
+   *
    * @param <T>
    * @param key
    * @param exp An expiration time, in seconds. Can be up to 30 days. After 30 days, is treated as a
@@ -807,7 +807,7 @@ public interface MemcachedClient {
   /**
    * cas is a check and set operation which means "store this data but only if no one else has
    * updated since I last fetched it."
-   * 
+   *
    * @param <T>
    * @param key
    * @param exp An expiration time, in seconds. Can be up to 30 days. After 30 days, is treated as a
@@ -883,7 +883,7 @@ public interface MemcachedClient {
       throws TimeoutException, InterruptedException, MemcachedException;
 
   /**
-   * 
+   *
    * @param <T>
    * @param key
    * @param getsResponse
@@ -899,7 +899,7 @@ public interface MemcachedClient {
 
   /**
    * cas noreply
-   * 
+   *
    * @param <T>
    * @param key
    * @param exp
@@ -949,7 +949,7 @@ public interface MemcachedClient {
    * the item is finally deleted from server memory. </br>
    * <strong>Note: This method is deprecated,because memcached 1.4.0 remove the optional argument
    * "time".You can still use this method on old version,but is not recommended.</strong>
-   * 
+   *
    * @param key
    * @param time
    * @throws InterruptedException
@@ -961,7 +961,7 @@ public interface MemcachedClient {
 
   /**
    * Delete key's date item from memcached
-   * 
+   *
    * @param key
    * @param opTimeout Operation timeout
    * @return
@@ -975,7 +975,7 @@ public interface MemcachedClient {
 
   /**
    * Delete key's date item from memcached only if its cas value is the same as what was read.
-   * 
+   *
    * @param key
    * @cas cas on delete to make sure the key is deleted only if its value is same as what was read.
    * @param opTimeout Operation timeout
@@ -990,7 +990,7 @@ public interface MemcachedClient {
 
   /**
    * Set a new expiration time for an existing item
-   * 
+   *
    * @param key item's key
    * @param exp New expiration time, in seconds. Can be up to 30 days. After 30 days, is treated as
    *        a unix timestamp of an exact date.
@@ -1005,7 +1005,7 @@ public interface MemcachedClient {
 
   /**
    * Set a new expiration time for an existing item,using default opTimeout second.
-   * 
+   *
    * @param key item's key
    * @param exp New expiration time, in seconds. Can be up to 30 days. After 30 days, is treated as
    *        a unix timestamp of an exact date.
@@ -1019,7 +1019,7 @@ public interface MemcachedClient {
 
   /**
    * Get item and set a new expiration time for it
-   * 
+   *
    * @param <T>
    * @param key item's key
    * @param newExp New expiration time, in seconds. Can be up to 30 days. After 30 days, is treated
@@ -1035,7 +1035,7 @@ public interface MemcachedClient {
 
   /**
    * Get item and set a new expiration time for it,using default opTimeout
-   * 
+   *
    * @param <T>
    * @param key
    * @param newExp
@@ -1049,7 +1049,7 @@ public interface MemcachedClient {
 
   /**
    * Bulk get items and touch them
-   * 
+   *
    * @param <T>
    * @param keyExpMap A map,key is item's key,and value is a new expiration time for the item.
    * @param opTimeout operation timeout
@@ -1064,7 +1064,7 @@ public interface MemcachedClient {
 
   /**
    * Bulk get items and touch them,using default opTimeout
-   * 
+   *
    * @see #getAndTouch(Map, long)
    * @param <T>
    * @param keyExpMap
@@ -1078,7 +1078,7 @@ public interface MemcachedClient {
 
   /**
    * Get all connected memcached servers's version.
-   * 
+   *
    * @return
    * @throws TimeoutException
    * @throws InterruptedException
@@ -1093,7 +1093,7 @@ public interface MemcachedClient {
    * does not conform to such a representation, the commands behave as if the value were 0. Also,
    * the item must already exist for incr to work; these commands won't pretend that a non-existent
    * key exists with value 0; instead, it will fail.This method doesn't wait for reply.
-   * 
+   *
    * @return the new value of the item's data, after the increment operation was carried out.
    * @param key
    * @param num
@@ -1112,7 +1112,7 @@ public interface MemcachedClient {
    * does not conform to such a representation, the commands behave as if the value were 0. Also,
    * the item must already exist for incr to work; these commands won't pretend that a non-existent
    * key exists with value 0; instead, it will fail.This method doesn't wait for reply.
-   * 
+   *
    * @param key key
    * @param num increment
    * @param initValue initValue if the data is not exists.
@@ -1131,7 +1131,7 @@ public interface MemcachedClient {
    * does not conform to such a representation, the commands behave as if the value were 0. Also,
    * the item must already exist for decr to work; these commands won't pretend that a non-existent
    * key exists with value 0; instead, it will fail.This method doesn't wait for reply.
-   * 
+   *
    * @return the new value of the item's data, after the decrement operation was carried out.
    * @param key
    * @param num
@@ -1160,7 +1160,7 @@ public interface MemcachedClient {
    * does not conform to such a representation, the commands behave as if the value were 0. Also,
    * the item must already exist for decr to work; these commands won't pretend that a non-existent
    * key exists with value 0; instead, it will fail.This method doesn't wait for reply.
-   * 
+   *
    * @param key The key
    * @param num The increment
    * @param initValue The initial value if the data is not exists.
@@ -1175,7 +1175,7 @@ public interface MemcachedClient {
 
   /**
    * Make All connected memcached's data item invalid
-   * 
+   *
    * @throws TimeoutException
    * @throws InterruptedException
    * @throws MemcachedException
@@ -1186,7 +1186,7 @@ public interface MemcachedClient {
 
   /**
    * Make All connected memcached's data item invalid
-   * 
+   *
    * @param timeout operation timeout
    * @throws TimeoutException
    * @throws InterruptedException
@@ -1197,7 +1197,7 @@ public interface MemcachedClient {
 
   /**
    * Invalidate all existing items immediately
-   * 
+   *
    * @param address Target memcached server
    * @param timeout operation timeout
    * @throws TimeoutException
@@ -1215,10 +1215,10 @@ public interface MemcachedClient {
 
   /**
    * This method is deprecated,please use flushAll(InetSocketAddress) instead.
-   * 
+   *
    * @deprecated
    * @param host
-   * 
+   *
    * @throws TimeoutException
    * @throws InterruptedException
    * @throws MemcachedException
@@ -1232,7 +1232,7 @@ public interface MemcachedClient {
 
   /**
    * �ョ��瑰������emcached server缁��淇℃�
-   * 
+   *
    * @param address ����板�
    * @param timeout ���瓒��
    * @return
@@ -1245,7 +1245,7 @@ public interface MemcachedClient {
 
   /**
    * Get stats from all memcached servers
-   * 
+   *
    * @param timeout
    * @return server->item->value map
    * @throws MemcachedException
@@ -1260,7 +1260,7 @@ public interface MemcachedClient {
 
   /**
    * Get special item stats. "stats items" for example
-   * 
+   *
    * @param item
    * @return
    */
@@ -1274,7 +1274,7 @@ public interface MemcachedClient {
 
   /**
    * return default transcoder,default is SerializingTranscoder
-   * 
+   *
    * @return
    */
   @SuppressWarnings("unchecked")
@@ -1282,7 +1282,7 @@ public interface MemcachedClient {
 
   /**
    * set transcoder
-   * 
+   *
    * @param transcoder
    */
   @SuppressWarnings("unchecked")
@@ -1293,14 +1293,14 @@ public interface MemcachedClient {
 
   /**
    * get operation timeout setting
-   * 
+   *
    * @return
    */
   public long getOpTimeout();
 
   /**
    * set operation timeout,default is one second.
-   * 
+   *
    * @param opTimeout
    */
   public void setOpTimeout(long opTimeout);
@@ -1311,7 +1311,7 @@ public interface MemcachedClient {
   /**
    * Returns available memcached servers list.This method is drepcated,please use
    * getAvailableServers instead.
-   * 
+   *
    * @see #getAvailableServers()
    * @return
    */
@@ -1320,14 +1320,14 @@ public interface MemcachedClient {
 
   /**
    * Returns available memcached servers list.
-   * 
+   *
    * @return A available server collection
    */
   public Collection<InetSocketAddress> getAvailableServers();
 
   /**
    * add a memcached server to MemcachedClient
-   * 
+   *
    * @param server
    * @param port
    * @param weight
@@ -1344,7 +1344,7 @@ public interface MemcachedClient {
    * e 3</a> </br>
    * <strong>Note: This method is deprecated,because memcached 1.4.0 remove the optional argument
    * "time".You can still use this method on old version,but is not recommended.</strong>
-   * 
+   *
    * @param key
    * @param time
    * @throws InterruptedException
@@ -1362,7 +1362,7 @@ public interface MemcachedClient {
    * does not conform to such a representation, the commands behave as if the value were 0. Also,
    * the item must already exist for incr to work; these commands won't pretend that a non-existent
    * key exists with value 0; instead, it will fail.This method doesn't wait for reply.
-   * 
+   *
    * @param key
    * @param num
    * @throws InterruptedException
@@ -1377,7 +1377,7 @@ public interface MemcachedClient {
    * does not conform to such a representation, the commands behave as if the value were 0. Also,
    * the item must already exist for decr to work; these commands won't pretend that a non-existent
    * key exists with value 0; instead, it will fail.This method doesn't wait for reply.
-   * 
+   *
    * @param key
    * @param num
    * @throws InterruptedException
@@ -1388,7 +1388,7 @@ public interface MemcachedClient {
 
   /**
    * Set the verbosity level of the memcached's logging output.This method will wait for reply.
-   * 
+   *
    * @param address
    * @param level logging level
    * @throws TimeoutException
@@ -1401,7 +1401,7 @@ public interface MemcachedClient {
   /**
    * Set the verbosity level of the memcached's logging output.This method doesn't wait for reply
    * from server
-   * 
+   *
    * @param address memcached server address
    * @param level logging level
    * @throws InterruptedException
@@ -1412,21 +1412,21 @@ public interface MemcachedClient {
 
   /**
    * Add a memcached client listener
-   * 
+   *
    * @param listener
    */
   public void addStateListener(MemcachedClientStateListener listener);
 
   /**
    * Remove a memcached client listener
-   * 
+   *
    * @param listener
    */
   public void removeStateListener(MemcachedClientStateListener listener);
 
   /**
    * Get all current state listeners
-   * 
+   *
    * @return
    */
   public Collection<MemcachedClientStateListener> getStateListeners();
@@ -1446,7 +1446,7 @@ public interface MemcachedClient {
    * If the memcached dump or network error cause connection closed,xmemcached would try to heal the
    * connection.The interval between reconnections is 2 seconds by default. You can change that
    * value by this method.
-   * 
+   *
    * @param healConnectionInterval MILLISECONDS
    */
   public void setHealSessionInterval(long healConnectionInterval);
@@ -1456,7 +1456,7 @@ public interface MemcachedClient {
    * connection.You can disable this behaviour by using this method:<br/>
    * <code> client.setEnableHealSession(false); </code><br/>
    * The default value is true.
-   * 
+   *
    * @param enableHealSession
    * @since 1.3.9
    */
@@ -1464,7 +1464,7 @@ public interface MemcachedClient {
 
   /**
    * Return the default heal session interval in milliseconds
-   * 
+   *
    * @return
    */
   public long getHealSessionInterval();
@@ -1482,21 +1482,21 @@ public interface MemcachedClient {
    * very large. Xmemcached supports connection pool instreadof client pool.you can create more
    * connections to one or more memcached servers,and these connections share the same reactor and
    * thread pools,it will reduce the cost of system.
-   * 
+   *
    * @param poolSize pool size,default is one,every memcached has only one connection.
    */
   public void setConnectionPoolSize(int poolSize);
 
   /**
    * Whether to enable heart beat
-   * 
+   *
    * @param enableHeartBeat if true,then enable heartbeat,true by default
    */
   public void setEnableHeartBeat(boolean enableHeartBeat);
 
   /**
    * Enables/disables sanitizing keys by URLEncoding.
-   * 
+   *
    * @param sanitizeKey if true, then URLEncode all keys
    */
   public void setSanitizeKeys(boolean sanitizeKey);
@@ -1505,7 +1505,7 @@ public interface MemcachedClient {
 
   /**
    * Get counter for key,and if the key's value is not set,then set it with 0.
-   * 
+   *
    * @param key
    * @return
    */
@@ -1513,7 +1513,7 @@ public interface MemcachedClient {
 
   /**
    * Get counter for key,and if the key's value is not set,then set it with initial value.
-   * 
+   *
    * @param key
    * @param initialValue
    * @return
@@ -1525,7 +1525,7 @@ public interface MemcachedClient {
    * for memcached all keys,it is not real-time.The 'stats cachedump" has length limitation,so
    * iterator could not visit all keys if you have many keys.Your application should not be
    * dependent on this feature.
-   * 
+   *
    * @deprecated memcached 1.6.x will remove cachedump stats command,so this method will be removed
    *             in the future
    * @param address
@@ -1537,7 +1537,7 @@ public interface MemcachedClient {
 
   /**
    * Configure auth info
-   * 
+   *
    * @param map Auth info map,key is memcached server address,and value is the auth info for the
    *        key.
    */
@@ -1545,7 +1545,7 @@ public interface MemcachedClient {
 
   /**
    * return current all auth info
-   * 
+   *
    * @return Auth info map,key is memcached server address,and value is the auth info for the key.
    */
   public Map<InetSocketAddress, AuthInfo> getAuthInfoMap();
@@ -1556,7 +1556,7 @@ public interface MemcachedClient {
    * does not conform to such a representation, the commands behave as if the value were 0. Also,
    * the item must already exist for incr to work; these commands won't pretend that a non-existent
    * key exists with value 0; instead, it will fail.This method doesn't wait for reply.
-   * 
+   *
    * @param key
    * @param delta
    * @param initValue the initial value to be added when value is not found
@@ -1577,7 +1577,7 @@ public interface MemcachedClient {
    * does not conform to such a representation, the commands behave as if the value were 0. Also,
    * the item must already exist for incr to work; these commands won't pretend that a non-existent
    * key exists with value 0; instead, it will fail.This method doesn't wait for reply.
-   * 
+   *
    * @param key key
    * @param delta increment delta
    * @param initValue the initial value to be added when value is not found
@@ -1594,14 +1594,14 @@ public interface MemcachedClient {
 
   /**
    * Return the cache instance name
-   * 
+   *
    * @return
    */
   public String getName();
 
   /**
    * Set cache instance name
-   * 
+   *
    * @param name
    */
   public void setName(String name);
@@ -1609,7 +1609,7 @@ public interface MemcachedClient {
   /**
    * Returns reconnecting task queue,the queue is thread-safe and 'weakly consistent',but maybe you
    * <strong>should not modify it</strong> at all.
-   * 
+   *
    * @return The reconnecting task queue,if the client has not been started,returns null.
    */
   public Queue<ReconnectRequest> getReconnectRequestQueue();
@@ -1620,21 +1620,21 @@ public interface MemcachedClient {
    * not taken from the server list but marked as unavailable,and then further requests to this
    * server will be transformed to standby node if configured or throw an exception until it comes
    * back up.
-   * 
+   *
    * @param failureMode true is to configure client in failure mode.
    */
   public void setFailureMode(boolean failureMode);
 
   /**
    * Returns if client is in failure mode.
-   * 
+   *
    * @return
    */
   public boolean isFailureMode();
 
   /**
    * Set a key provider for pre-processing keys before sending them to memcached.
-   * 
+   *
    * @since 1.3.8
    * @param keyProvider
    */
@@ -1642,7 +1642,7 @@ public interface MemcachedClient {
 
   /**
    * Returns maximum number of timeout exception for closing connection.
-   * 
+   *
    * @return
    */
   public int getTimeoutExceptionThreshold();
@@ -1650,7 +1650,7 @@ public interface MemcachedClient {
   /**
    * Set maximum number of timeout exception for closing connection.You can set it to be a large
    * value to disable this feature.
-   * 
+   *
    * @see #DEFAULT_MAX_TIMEOUTEXCEPTION_THRESHOLD
    * @param timeoutExceptionThreshold
    */
@@ -1658,7 +1658,7 @@ public interface MemcachedClient {
 
   /**
    * Invalidate all namespace under the namespace using the default operation timeout.
-   * 
+   *
    * @since 1.4.2
    * @param ns the namespace
    * @throws MemcachedException
@@ -1670,7 +1670,7 @@ public interface MemcachedClient {
 
   /**
    * Invalidate all items under the namespace.
-   * 
+   *
    * @since 1.4.2
    * @param ns the namespace
    * @param opTimeout operation timeout in milliseconds.
@@ -1684,7 +1684,7 @@ public interface MemcachedClient {
   /**
    * Remove current namespace set for this memcached client.It must begin with
    * {@link #beginWithNamespace(String)} method.
-   * 
+   *
    * @see #beginWithNamespace(String)
    */
   public void endWithNamespace();
@@ -1692,7 +1692,7 @@ public interface MemcachedClient {
   /**
    * set current namespace for following operations with memcached client.It must be ended with
    * {@link #endWithNamespace()} method.For example:
-   * 
+   *
    * <pre>
    * memcachedClient.beginWithNamespace(userId);
    * try {
@@ -1702,7 +1702,7 @@ public interface MemcachedClient {
    *   memcachedClient.endWithNamespace();
    * }
    * </pre>
-   * 
+   *
    * @see #endWithNamespace()
    * @see #withNamespace(String, MemcachedClientCallable)
    * @param ns
@@ -1713,7 +1713,7 @@ public interface MemcachedClient {
    * With the namespae to do something with current memcached client.All operations with memcached
    * client done in callable will be under the namespace. {@link #beginWithNamespace(String)} and
    * {@link #endWithNamespace()} will called around automatically. For example:
-   * 
+   *
    * <pre>
    *   memcachedClient.withNamespace(userId,new MemcachedClientCallable<Void>{
    *     public Void call(MemcachedClient client) throws MemcachedException,
@@ -1726,7 +1726,7 @@ public interface MemcachedClient {
    *   //invalidate all items under the namespace.
    *   memcachedClient.invalidateNamespace(userId);
    * </pre>
-   * 
+   *
    * @since 1.4.2
    * @param ns
    * @param callable

--- a/src/main/java/net/rubyeye/xmemcached/MemcachedClient.java
+++ b/src/main/java/net/rubyeye/xmemcached/MemcachedClient.java
@@ -1551,6 +1551,13 @@ public interface MemcachedClient {
   public Map<InetSocketAddress, AuthInfo> getAuthInfoMap();
 
   /**
+   * Retruns the AuthInfo for all server strings (hostname:port)
+   *
+   * @return A map of AuthInfos for server strings (hostname:port)
+   */
+  public Map<String, AuthInfo> getAuthInfoStringMap();
+
+  /**
    * "incr" are used to change data for some item in-place, incrementing it. The data for the item
    * is treated as decimal representation of a 64-bit unsigned integer. If the current data value
    * does not conform to such a representation, the commands behave as if the value were 0. Also,

--- a/src/main/java/net/rubyeye/xmemcached/XMemcachedClient.java
+++ b/src/main/java/net/rubyeye/xmemcached/XMemcachedClient.java
@@ -94,6 +94,7 @@ public class XMemcachedClient implements XMemcachedClientMBean, MemcachedClient 
   protected final AtomicInteger serverOrderCount = new AtomicInteger();
 
   private Map<InetSocketAddress, AuthInfo> authInfoMap = new HashMap<InetSocketAddress, AuthInfo>();
+  private Map<String, AuthInfo> authInfoStringMap = new HashMap<String, AuthInfo>();
 
   private String name; // cache name
 
@@ -263,6 +264,15 @@ public class XMemcachedClient implements XMemcachedClientMBean, MemcachedClient 
 
   public void setAuthInfoMap(Map<InetSocketAddress, AuthInfo> map) {
     this.authInfoMap = map;
+    this.authInfoStringMap = new HashMap<String, AuthInfo>();
+    for (Map.Entry<InetSocketAddress, AuthInfo> entry : map.entrySet()) {
+      String server = AddrUtil.getServerString(entry.getKey());
+      this.authInfoStringMap.put(server, entry.getValue());
+    }
+  }
+
+  public Map<String, AuthInfo> getAuthInfoStringMap() {
+    return this.authInfoStringMap;
   }
 
   /*

--- a/src/main/java/net/rubyeye/xmemcached/XMemcachedClient.java
+++ b/src/main/java/net/rubyeye/xmemcached/XMemcachedClient.java
@@ -71,9 +71,9 @@ import com.google.code.yanf4j.util.SystemUtils;
 
 /**
  * Memcached Client for connecting to memcached server and do operations.
- * 
+ *
  * @author dennis(killme2008@gmail.com)
- * 
+ *
  */
 public class XMemcachedClient implements XMemcachedClientMBean, MemcachedClient {
 
@@ -116,7 +116,7 @@ public class XMemcachedClient implements XMemcachedClientMBean, MemcachedClient 
 
   /*
    * (non-Javadoc)
-   * 
+   *
    * @see net.rubyeye.xmemcached.MemcachedClient#setMergeFactor(int)
    */
   public final void setMergeFactor(final int mergeFactor) {
@@ -195,7 +195,7 @@ public class XMemcachedClient implements XMemcachedClientMBean, MemcachedClient 
 
   /*
    * (non-Javadoc)
-   * 
+   *
    * @see net.rubyeye.xmemcached.MemcachedClient#getConnectTimeout()
    */
   public long getConnectTimeout() {
@@ -204,7 +204,7 @@ public class XMemcachedClient implements XMemcachedClientMBean, MemcachedClient 
 
   /*
    * (non-Javadoc)
-   * 
+   *
    * @see net.rubyeye.xmemcached.MemcachedClient#setConnectTimeout(long)
    */
   public void setConnectTimeout(long connectTimeout) {
@@ -220,7 +220,7 @@ public class XMemcachedClient implements XMemcachedClientMBean, MemcachedClient 
 
   /**
    * get operation timeout setting
-   * 
+   *
    * @return
    */
   public final long getOpTimeout() {
@@ -229,7 +229,7 @@ public class XMemcachedClient implements XMemcachedClientMBean, MemcachedClient 
 
   /**
    * set operation timeout,default is one second.
-   * 
+   *
    * @param opTimeout
    */
   public final void setOpTimeout(long opTimeout) {
@@ -267,7 +267,7 @@ public class XMemcachedClient implements XMemcachedClientMBean, MemcachedClient 
 
   /*
    * (non-Javadoc)
-   * 
+   *
    * @see net.rubyeye.xmemcached.MemcachedClient#getConnector()
    */
   public final Connector getConnector() {
@@ -276,7 +276,7 @@ public class XMemcachedClient implements XMemcachedClientMBean, MemcachedClient 
 
   /*
    * (non-Javadoc)
-   * 
+   *
    * @see net.rubyeye.xmemcached.MemcachedClient#setOptimizeMergeBuffer(boolean)
    */
   public final void setOptimizeMergeBuffer(final boolean optimizeMergeBuffer) {
@@ -285,7 +285,7 @@ public class XMemcachedClient implements XMemcachedClientMBean, MemcachedClient 
 
   /*
    * (non-Javadoc)
-   * 
+   *
    * @see net.rubyeye.xmemcached.MemcachedClient#isShutdown()
    */
   public final boolean isShutdown() {
@@ -310,7 +310,7 @@ public class XMemcachedClient implements XMemcachedClientMBean, MemcachedClient 
 
   /**
    * XMemcached constructor,default weight is 1
-   * 
+   *
    * @param server �����P
    * @param port ����ㄧ���
    * @throws IOException
@@ -321,7 +321,7 @@ public class XMemcachedClient implements XMemcachedClientMBean, MemcachedClient 
 
   /**
    * XMemcached constructor
-   * 
+   *
    * @param host server host
    * @param port server port
    * @param weight server weight
@@ -357,7 +357,7 @@ public class XMemcachedClient implements XMemcachedClientMBean, MemcachedClient 
 
   /*
    * (non-Javadoc)
-   * 
+   *
    * @see net.rubyeye.xmemcached.MemcachedClient#addServer(java.lang.String, int)
    */
   public final void addServer(final String server, final int port) throws IOException {
@@ -366,7 +366,7 @@ public class XMemcachedClient implements XMemcachedClientMBean, MemcachedClient 
 
   /**
    * add a memcached server to MemcachedClient
-   * 
+   *
    * @param server
    * @param port
    * @param weight
@@ -383,7 +383,7 @@ public class XMemcachedClient implements XMemcachedClientMBean, MemcachedClient 
 
   /*
    * (non-Javadoc)
-   * 
+   *
    * @see net.rubyeye.xmemcached.MemcachedClient#addServer(java.net. InetSocketAddress )
    */
   public final void addServer(final InetSocketAddress inetSocketAddress) throws IOException {
@@ -404,7 +404,7 @@ public class XMemcachedClient implements XMemcachedClientMBean, MemcachedClient 
 
   /*
    * (non-Javadoc)
-   * 
+   *
    * @see net.rubyeye.xmemcached.MemcachedClient#addServer(java.lang.String)
    */
   public final void addServer(String hostList) throws IOException {
@@ -451,7 +451,7 @@ public class XMemcachedClient implements XMemcachedClientMBean, MemcachedClient 
 
   /*
    * (non-Javadoc)
-   * 
+   *
    * @see net.rubyeye.xmemcached.MemcachedClient#getServersDescription()
    */
   public final List<String> getServersDescription() {
@@ -481,7 +481,7 @@ public class XMemcachedClient implements XMemcachedClientMBean, MemcachedClient 
 
   /*
    * (non-Javadoc)
-   * 
+   *
    * @see net.rubyeye.xmemcached.MemcachedClient#removeServer(java.lang.String)
    */
   public final void removeServer(String hostList) {
@@ -632,7 +632,7 @@ public class XMemcachedClient implements XMemcachedClientMBean, MemcachedClient 
 
   /**
    * Set max queued noreply operations number
-   * 
+   *
    * @param maxQueuedNoReplyOperations
    */
   void setMaxQueuedNoReplyOperations(int maxQueuedNoReplyOperations) {
@@ -709,7 +709,7 @@ public class XMemcachedClient implements XMemcachedClientMBean, MemcachedClient 
 
   /*
    * (non-Javadoc)
-   * 
+   *
    * @see net.rubyeye.xmemcached.MemcachedClient#setBufferAllocator(net.rubyeye
    * .xmemcached.buffer.BufferAllocator)
    */
@@ -719,7 +719,7 @@ public class XMemcachedClient implements XMemcachedClientMBean, MemcachedClient 
 
   /**
    * XMemcached Constructor.
-   * 
+   *
    * @param inetSocketAddress
    * @param weight
    * @throws IOException
@@ -766,7 +766,7 @@ public class XMemcachedClient implements XMemcachedClientMBean, MemcachedClient 
   /**
    * XMemcachedClient constructor.Every server's weight is one by default. You should not new client
    * instance by this method, use MemcachedClientBuilder instead.
-   * 
+   *
    * @param locator
    * @param allocator
    * @param conf
@@ -812,7 +812,7 @@ public class XMemcachedClient implements XMemcachedClientMBean, MemcachedClient 
 
   /**
    * XMemcachedClient constructor.
-   * 
+   *
    * @param locator
    * @param allocator
    * @param conf
@@ -897,7 +897,7 @@ public class XMemcachedClient implements XMemcachedClientMBean, MemcachedClient 
 
   /**
    * XMemcached Constructor.Every server's weight is one by default.
-   * 
+   *
    * @param addressList
    * @throws IOException
    */
@@ -907,7 +907,7 @@ public class XMemcachedClient implements XMemcachedClientMBean, MemcachedClient 
 
   /**
    * XMemcached Constructor.Every server's weight is one by default.
-   * 
+   *
    * @param cmdFactory command factory
    * @param addressList memcached server socket address list.
    * @throws IOException
@@ -935,7 +935,7 @@ public class XMemcachedClient implements XMemcachedClientMBean, MemcachedClient 
 
   /*
    * (non-Javadoc)
-   * 
+   *
    * @see net.rubyeye.xmemcached.MemcachedClient#get(java.lang.String, long,
    * net.rubyeye.xmemcached.transcoders.Transcoder)
    */
@@ -947,7 +947,7 @@ public class XMemcachedClient implements XMemcachedClientMBean, MemcachedClient 
 
   /*
    * (non-Javadoc)
-   * 
+   *
    * @see net.rubyeye.xmemcached.MemcachedClient#get(java.lang.String, long)
    */
   @SuppressWarnings("unchecked")
@@ -958,7 +958,7 @@ public class XMemcachedClient implements XMemcachedClientMBean, MemcachedClient 
 
   /*
    * (non-Javadoc)
-   * 
+   *
    * @see net.rubyeye.xmemcached.MemcachedClient#get(java.lang.String,
    * net.rubyeye.xmemcached.transcoders.Transcoder)
    */
@@ -969,7 +969,7 @@ public class XMemcachedClient implements XMemcachedClientMBean, MemcachedClient 
 
   /*
    * (non-Javadoc)
-   * 
+   *
    * @see net.rubyeye.xmemcached.MemcachedClient#get(java.lang.String)
    */
   @SuppressWarnings("unchecked")
@@ -989,7 +989,7 @@ public class XMemcachedClient implements XMemcachedClientMBean, MemcachedClient 
 
   /*
    * (non-Javadoc)
-   * 
+   *
    * @see net.rubyeye.xmemcached.MemcachedClient#gets(java.lang.String, long,
    * net.rubyeye.xmemcached.transcoders.Transcoder)
    */
@@ -1002,7 +1002,7 @@ public class XMemcachedClient implements XMemcachedClientMBean, MemcachedClient 
 
   /*
    * (non-Javadoc)
-   * 
+   *
    * @see net.rubyeye.xmemcached.MemcachedClient#gets(java.lang.String)
    */
   public final <T> GetsResponse<T> gets(final String key)
@@ -1012,7 +1012,7 @@ public class XMemcachedClient implements XMemcachedClientMBean, MemcachedClient 
 
   /*
    * (non-Javadoc)
-   * 
+   *
    * @see net.rubyeye.xmemcached.MemcachedClient#gets(java.lang.String, long)
    */
   @SuppressWarnings("unchecked")
@@ -1023,7 +1023,7 @@ public class XMemcachedClient implements XMemcachedClientMBean, MemcachedClient 
 
   /*
    * (non-Javadoc)
-   * 
+   *
    * @see net.rubyeye.xmemcached.MemcachedClient#gets(java.lang.String,
    * net.rubyeye.xmemcached.transcoders.Transcoder)
    */
@@ -1035,7 +1035,7 @@ public class XMemcachedClient implements XMemcachedClientMBean, MemcachedClient 
 
   /*
    * (non-Javadoc)
-   * 
+   *
    * @see net.rubyeye.xmemcached.MemcachedClient#get(java.util.Collection, long,
    * net.rubyeye.xmemcached.transcoders.Transcoder)
    */
@@ -1047,7 +1047,7 @@ public class XMemcachedClient implements XMemcachedClientMBean, MemcachedClient 
 
   /*
    * (non-Javadoc)
-   * 
+   *
    * @see net.rubyeye.xmemcached.MemcachedClient#get(java.util.Collection,
    * net.rubyeye.xmemcached.transcoders.Transcoder)
    */
@@ -1059,7 +1059,7 @@ public class XMemcachedClient implements XMemcachedClientMBean, MemcachedClient 
 
   /*
    * (non-Javadoc)
-   * 
+   *
    * @see net.rubyeye.xmemcached.MemcachedClient#get(java.util.Collection)
    */
   public final <T> Map<String, T> get(final Collection<String> keyCollections)
@@ -1069,7 +1069,7 @@ public class XMemcachedClient implements XMemcachedClientMBean, MemcachedClient 
 
   /*
    * (non-Javadoc)
-   * 
+   *
    * @see net.rubyeye.xmemcached.MemcachedClient#get(java.util.Collection, long)
    */
   @SuppressWarnings("unchecked")
@@ -1080,7 +1080,7 @@ public class XMemcachedClient implements XMemcachedClientMBean, MemcachedClient 
 
   /*
    * (non-Javadoc)
-   * 
+   *
    * @see net.rubyeye.xmemcached.MemcachedClient#gets(java.util.Collection, long,
    * net.rubyeye.xmemcached.transcoders.Transcoder)
    */
@@ -1094,7 +1094,7 @@ public class XMemcachedClient implements XMemcachedClientMBean, MemcachedClient 
 
   /*
    * (non-Javadoc)
-   * 
+   *
    * @see net.rubyeye.xmemcached.MemcachedClient#gets(java.util.Collection)
    */
   public final <T> Map<String, GetsResponse<T>> gets(final Collection<String> keyCollections)
@@ -1104,7 +1104,7 @@ public class XMemcachedClient implements XMemcachedClientMBean, MemcachedClient 
 
   /*
    * (non-Javadoc)
-   * 
+   *
    * @see net.rubyeye.xmemcached.MemcachedClient#gets(java.util.Collection, long)
    */
   @SuppressWarnings("unchecked")
@@ -1115,7 +1115,7 @@ public class XMemcachedClient implements XMemcachedClientMBean, MemcachedClient 
 
   /*
    * (non-Javadoc)
-   * 
+   *
    * @see net.rubyeye.xmemcached.MemcachedClient#gets(java.util.Collection,
    * net.rubyeye.xmemcached.transcoders.Transcoder)
    */
@@ -1198,7 +1198,7 @@ public class XMemcachedClient implements XMemcachedClientMBean, MemcachedClient 
 
   /**
    * Hash key to servers
-   * 
+   *
    * @param keyCollections
    * @return
    */
@@ -1230,7 +1230,7 @@ public class XMemcachedClient implements XMemcachedClientMBean, MemcachedClient 
 
   /*
    * (non-Javadoc)
-   * 
+   *
    * @see net.rubyeye.xmemcached.MemcachedClient#set(java.lang.String, int, T,
    * net.rubyeye.xmemcached.transcoders.Transcoder, long)
    */
@@ -1277,7 +1277,7 @@ public class XMemcachedClient implements XMemcachedClientMBean, MemcachedClient 
 
   /*
    * (non-Javadoc)
-   * 
+   *
    * @see net.rubyeye.xmemcached.MemcachedClient#set(java.lang.String, int, java.lang.Object)
    */
   public final boolean set(final String key, final int exp, final Object value)
@@ -1287,7 +1287,7 @@ public class XMemcachedClient implements XMemcachedClientMBean, MemcachedClient 
 
   /*
    * (non-Javadoc)
-   * 
+   *
    * @see net.rubyeye.xmemcached.MemcachedClient#set(java.lang.String, int, java.lang.Object, long)
    */
   @SuppressWarnings("unchecked")
@@ -1298,7 +1298,7 @@ public class XMemcachedClient implements XMemcachedClientMBean, MemcachedClient 
 
   /*
    * (non-Javadoc)
-   * 
+   *
    * @see net.rubyeye.xmemcached.MemcachedClient#set(java.lang.String, int, T,
    * net.rubyeye.xmemcached.transcoders.Transcoder)
    */
@@ -1310,7 +1310,7 @@ public class XMemcachedClient implements XMemcachedClientMBean, MemcachedClient 
 
   /*
    * (non-Javadoc)
-   * 
+   *
    * @see net.rubyeye.xmemcached.MemcachedClient#add(java.lang.String, int, T,
    * net.rubyeye.xmemcached.transcoders.Transcoder, long)
    */
@@ -1331,7 +1331,7 @@ public class XMemcachedClient implements XMemcachedClientMBean, MemcachedClient 
 
   /*
    * (non-Javadoc)
-   * 
+   *
    * @see net.rubyeye.xmemcached.MemcachedClient#add(java.lang.String, int, java.lang.Object)
    */
   public final boolean add(final String key, final int exp, final Object value)
@@ -1341,7 +1341,7 @@ public class XMemcachedClient implements XMemcachedClientMBean, MemcachedClient 
 
   /*
    * (non-Javadoc)
-   * 
+   *
    * @see net.rubyeye.xmemcached.MemcachedClient#add(java.lang.String, int, java.lang.Object, long)
    */
   @SuppressWarnings("unchecked")
@@ -1352,7 +1352,7 @@ public class XMemcachedClient implements XMemcachedClientMBean, MemcachedClient 
 
   /*
    * (non-Javadoc)
-   * 
+   *
    * @see net.rubyeye.xmemcached.MemcachedClient#add(java.lang.String, int, T,
    * net.rubyeye.xmemcached.transcoders.Transcoder)
    */
@@ -1406,7 +1406,7 @@ public class XMemcachedClient implements XMemcachedClientMBean, MemcachedClient 
 
   /*
    * (non-Javadoc)
-   * 
+   *
    * @see net.rubyeye.xmemcached.MemcachedClient#replace(java.lang.String, int, T,
    * net.rubyeye.xmemcached.transcoders.Transcoder, long)
    */
@@ -1422,7 +1422,7 @@ public class XMemcachedClient implements XMemcachedClientMBean, MemcachedClient 
 
   /*
    * (non-Javadoc)
-   * 
+   *
    * @see net.rubyeye.xmemcached.MemcachedClient#replace(java.lang.String, int, java.lang.Object)
    */
   public final boolean replace(final String key, final int exp, final Object value)
@@ -1432,7 +1432,7 @@ public class XMemcachedClient implements XMemcachedClientMBean, MemcachedClient 
 
   /*
    * (non-Javadoc)
-   * 
+   *
    * @see net.rubyeye.xmemcached.MemcachedClient#replace(java.lang.String, int, java.lang.Object,
    * long)
    */
@@ -1444,7 +1444,7 @@ public class XMemcachedClient implements XMemcachedClientMBean, MemcachedClient 
 
   /*
    * (non-Javadoc)
-   * 
+   *
    * @see net.rubyeye.xmemcached.MemcachedClient#replace(java.lang.String, int, T,
    * net.rubyeye.xmemcached.transcoders.Transcoder)
    */
@@ -1456,7 +1456,7 @@ public class XMemcachedClient implements XMemcachedClientMBean, MemcachedClient 
 
   /*
    * (non-Javadoc)
-   * 
+   *
    * @see net.rubyeye.xmemcached.MemcachedClient#append(java.lang.String, java.lang.Object)
    */
   public final boolean append(final String key, final Object value)
@@ -1466,7 +1466,7 @@ public class XMemcachedClient implements XMemcachedClientMBean, MemcachedClient 
 
   /*
    * (non-Javadoc)
-   * 
+   *
    * @see net.rubyeye.xmemcached.MemcachedClient#append(java.lang.String, java.lang.Object, long)
    */
   public final boolean append(String key, final Object value, final long timeout)
@@ -1494,7 +1494,7 @@ public class XMemcachedClient implements XMemcachedClientMBean, MemcachedClient 
 
   /*
    * (non-Javadoc)
-   * 
+   *
    * @see net.rubyeye.xmemcached.MemcachedClient#prepend(java.lang.String, java.lang.Object)
    */
   public final boolean prepend(final String key, final Object value)
@@ -1504,7 +1504,7 @@ public class XMemcachedClient implements XMemcachedClientMBean, MemcachedClient 
 
   /*
    * (non-Javadoc)
-   * 
+   *
    * @see net.rubyeye.xmemcached.MemcachedClient#prepend(java.lang.String, java.lang.Object, long)
    */
   public final boolean prepend(String key, final Object value, final long timeout)
@@ -1531,7 +1531,7 @@ public class XMemcachedClient implements XMemcachedClientMBean, MemcachedClient 
 
   /*
    * (non-Javadoc)
-   * 
+   *
    * @see net.rubyeye.xmemcached.MemcachedClient#cas(java.lang.String, int, java.lang.Object, long)
    */
   public final boolean cas(final String key, final int exp, final Object value, final long cas)
@@ -1541,7 +1541,7 @@ public class XMemcachedClient implements XMemcachedClientMBean, MemcachedClient 
 
   /*
    * (non-Javadoc)
-   * 
+   *
    * @see net.rubyeye.xmemcached.MemcachedClient#cas(java.lang.String, int, T,
    * net.rubyeye.xmemcached.transcoders.Transcoder, long, long)
    */
@@ -1557,7 +1557,7 @@ public class XMemcachedClient implements XMemcachedClientMBean, MemcachedClient 
 
   /*
    * (non-Javadoc)
-   * 
+   *
    * @see net.rubyeye.xmemcached.MemcachedClient#cas(java.lang.String, int, java.lang.Object, long,
    * long)
    */
@@ -1569,7 +1569,7 @@ public class XMemcachedClient implements XMemcachedClientMBean, MemcachedClient 
 
   /*
    * (non-Javadoc)
-   * 
+   *
    * @see net.rubyeye.xmemcached.MemcachedClient#cas(java.lang.String, int, T,
    * net.rubyeye.xmemcached.transcoders.Transcoder, long)
    */
@@ -1612,7 +1612,7 @@ public class XMemcachedClient implements XMemcachedClientMBean, MemcachedClient 
 
   /*
    * (non-Javadoc)
-   * 
+   *
    * @see net.rubyeye.xmemcached.MemcachedClient#cas(java.lang.String, int,
    * net.rubyeye.xmemcached.CASOperation, net.rubyeye.xmemcached.transcoders.Transcoder)
    */
@@ -1628,7 +1628,7 @@ public class XMemcachedClient implements XMemcachedClientMBean, MemcachedClient 
 
   /*
    * (non-Javadoc)
-   * 
+   *
    * @see net.rubyeye.xmemcached.MemcachedClient#cas(java.lang.String, int,
    * net.rubyeye.xmemcached.GetsResponse, net.rubyeye.xmemcached.CASOperation,
    * net.rubyeye.xmemcached.transcoders.Transcoder)
@@ -1644,7 +1644,7 @@ public class XMemcachedClient implements XMemcachedClientMBean, MemcachedClient 
 
   /*
    * (non-Javadoc)
-   * 
+   *
    * @see net.rubyeye.xmemcached.MemcachedClient#cas(java.lang.String, int,
    * net.rubyeye.xmemcached.GetsResponse, net.rubyeye.xmemcached.CASOperation)
    */
@@ -1689,7 +1689,7 @@ public class XMemcachedClient implements XMemcachedClientMBean, MemcachedClient 
 
   /*
    * (non-Javadoc)
-   * 
+   *
    * @see net.rubyeye.xmemcached.MemcachedClient#cas(java.lang.String,
    * net.rubyeye.xmemcached.GetsResponse, net.rubyeye.xmemcached.CASOperation)
    */
@@ -1701,7 +1701,7 @@ public class XMemcachedClient implements XMemcachedClientMBean, MemcachedClient 
 
   /*
    * (non-Javadoc)
-   * 
+   *
    * @see net.rubyeye.xmemcached.MemcachedClient#cas(java.lang.String, int,
    * net.rubyeye.xmemcached.CASOperation)
    */
@@ -1713,7 +1713,7 @@ public class XMemcachedClient implements XMemcachedClientMBean, MemcachedClient 
 
   /*
    * (non-Javadoc)
-   * 
+   *
    * @see net.rubyeye.xmemcached.MemcachedClient#cas(java.lang.String,
    * net.rubyeye.xmemcached.CASOperation)
    */
@@ -1724,7 +1724,7 @@ public class XMemcachedClient implements XMemcachedClientMBean, MemcachedClient 
 
   /*
    * (non-Javadoc)
-   * 
+   *
    * @see net.rubyeye.xmemcached.MemcachedClient#delete(java.lang.String, int)
    */
   public final boolean delete(final String key, final int time)
@@ -1744,7 +1744,7 @@ public class XMemcachedClient implements XMemcachedClientMBean, MemcachedClient 
 
   /**
    * Delete key's data item from memcached.This method doesn't wait for reply
-   * 
+   *
    * @param key
    * @param time
    * @throws InterruptedException
@@ -1844,7 +1844,7 @@ public class XMemcachedClient implements XMemcachedClientMBean, MemcachedClient 
 
   /*
    * (non-Javadoc)
-   * 
+   *
    * @see net.rubyeye.xmemcached.MemcachedClient#incr(java.lang.String, int)
    */
   public final long incr(String key, final long delta)
@@ -1894,7 +1894,7 @@ public class XMemcachedClient implements XMemcachedClientMBean, MemcachedClient 
 
   /*
    * (non-Javadoc)
-   * 
+   *
    * @see net.rubyeye.xmemcached.MemcachedClient#decr(java.lang.String, int)
    */
   public final long decr(String key, final long delta)
@@ -1924,7 +1924,7 @@ public class XMemcachedClient implements XMemcachedClientMBean, MemcachedClient 
 
   /*
    * (non-Javadoc)
-   * 
+   *
    * @see net.rubyeye.xmemcached.MemcachedClient#flushAll()
    */
   public final void flushAll() throws TimeoutException, InterruptedException, MemcachedException {
@@ -1972,7 +1972,7 @@ public class XMemcachedClient implements XMemcachedClientMBean, MemcachedClient 
 
   /*
    * (non-Javadoc)
-   * 
+   *
    * @see net.rubyeye.xmemcached.MemcachedClient#flushAll(long)
    */
   public final void flushAll(long timeout)
@@ -2044,7 +2044,7 @@ public class XMemcachedClient implements XMemcachedClientMBean, MemcachedClient 
 
   /*
    * (non-Javadoc)
-   * 
+   *
    * @see net.rubyeye.xmemcached.MemcachedClient#flushAll(java.net. InetSocketAddress )
    */
   public final void flushAll(InetSocketAddress address)
@@ -2054,7 +2054,7 @@ public class XMemcachedClient implements XMemcachedClientMBean, MemcachedClient 
 
   /*
    * (non-Javadoc)
-   * 
+   *
    * @see net.rubyeye.xmemcached.MemcachedClient#flushAll(java.net. InetSocketAddress , long)
    */
   public final void flushAll(InetSocketAddress address, long timeout)
@@ -2090,7 +2090,7 @@ public class XMemcachedClient implements XMemcachedClientMBean, MemcachedClient 
 
   /*
    * (non-Javadoc)
-   * 
+   *
    * @see net.rubyeye.xmemcached.MemcachedClient#flushAll(java.lang.String)
    */
   public final void flushAll(String host)
@@ -2100,7 +2100,7 @@ public class XMemcachedClient implements XMemcachedClientMBean, MemcachedClient 
 
   /*
    * (non-Javadoc)
-   * 
+   *
    * @see net.rubyeye.xmemcached.MemcachedClient#stats(java.net.InetSocketAddress)
    */
   public final Map<String, String> stats(InetSocketAddress address)
@@ -2110,7 +2110,7 @@ public class XMemcachedClient implements XMemcachedClientMBean, MemcachedClient 
 
   /*
    * (non-Javadoc)
-   * 
+   *
    * @see net.rubyeye.xmemcached.MemcachedClient#stats(java.net.InetSocketAddress, long)
    */
   @SuppressWarnings("unchecked")
@@ -2226,7 +2226,7 @@ public class XMemcachedClient implements XMemcachedClientMBean, MemcachedClient 
 
   /*
    * (non-Javadoc)
-   * 
+   *
    * @see net.rubyeye.xmemcached.MemcachedClient#shutdown()
    */
   public final void shutdown() throws IOException {
@@ -2298,7 +2298,7 @@ public class XMemcachedClient implements XMemcachedClientMBean, MemcachedClient 
 
   /*
    * (non-Javadoc)
-   * 
+   *
    * @see net.rubyeye.xmemcached.MemcachedClient#delete(java.lang.String)
    */
   public final boolean delete(final String key)
@@ -2308,7 +2308,7 @@ public class XMemcachedClient implements XMemcachedClientMBean, MemcachedClient 
 
   /*
    * (non-Javadoc)
-   * 
+   *
    * @see net.rubyeye.xmemcached.MemcachedClient#getTranscoder()
    */
   @SuppressWarnings("unchecked")
@@ -2318,7 +2318,7 @@ public class XMemcachedClient implements XMemcachedClientMBean, MemcachedClient 
 
   /*
    * (non-Javadoc)
-   * 
+   *
    * @see net.rubyeye.xmemcached.MemcachedClient#setTranscoder(net.rubyeye. xmemcached
    * .transcoders.Transcoder)
    */
@@ -2387,7 +2387,7 @@ public class XMemcachedClient implements XMemcachedClientMBean, MemcachedClient 
 
   /**
    * Use getAvailableServers() instead
-   * 
+   *
    * @deprecated
    * @see MemcachedClient#getAvailableServers()
    */
@@ -2506,7 +2506,7 @@ public class XMemcachedClient implements XMemcachedClientMBean, MemcachedClient 
 
   /**
    * Returns the real namespace of ns.
-   * 
+   *
    * @param ns
    * @return
    * @throws TimeoutException

--- a/src/main/java/net/rubyeye/xmemcached/XMemcachedClientBuilder.java
+++ b/src/main/java/net/rubyeye/xmemcached/XMemcachedClientBuilder.java
@@ -26,9 +26,9 @@ import com.google.code.yanf4j.core.impl.StandardSocketOption;
 
 /**
  * Builder pattern.Configure XmemcachedClient's options,then build it
- * 
+ *
  * @author dennis
- * 
+ *
  */
 public class XMemcachedClientBuilder implements MemcachedClientBuilder {
 
@@ -103,7 +103,7 @@ public class XMemcachedClientBuilder implements MemcachedClientBuilder {
 
   /**
    * Set max queued noreply operations number
-   * 
+   *
    * @see MemcachedClient#DEFAULT_MAX_QUEUED_NOPS
    * @param maxQueuedNoReplyOperations
    * @since 1.3.8
@@ -245,7 +245,7 @@ public class XMemcachedClientBuilder implements MemcachedClientBuilder {
 
   /*
    * (non-Javadoc)
-   * 
+   *
    * @see net.rubyeye.xmemcached.MemcachedClientBuilder#getSessionLocator()
    */
   public MemcachedSessionLocator getSessionLocator() {
@@ -254,7 +254,7 @@ public class XMemcachedClientBuilder implements MemcachedClientBuilder {
 
   /*
    * (non-Javadoc)
-   * 
+   *
    * @see net.rubyeye.xmemcached.MemcachedClientBuilder#setSessionLocator(net. rubyeye
    * .xmemcached.MemcachedSessionLocator)
    */
@@ -267,7 +267,7 @@ public class XMemcachedClientBuilder implements MemcachedClientBuilder {
 
   /*
    * (non-Javadoc)
-   * 
+   *
    * @see net.rubyeye.xmemcached.MemcachedClientBuilder#getBufferAllocator()
    */
   public BufferAllocator getBufferAllocator() {
@@ -276,7 +276,7 @@ public class XMemcachedClientBuilder implements MemcachedClientBuilder {
 
   /*
    * (non-Javadoc)
-   * 
+   *
    * @see net.rubyeye.xmemcached.MemcachedClientBuilder#setBufferAllocator(net.
    * rubyeye.xmemcached.buffer.BufferAllocator)
    */
@@ -289,7 +289,7 @@ public class XMemcachedClientBuilder implements MemcachedClientBuilder {
 
   /*
    * (non-Javadoc)
-   * 
+   *
    * @see net.rubyeye.xmemcached.MemcachedClientBuilder#getConfiguration()
    */
   public Configuration getConfiguration() {
@@ -298,7 +298,7 @@ public class XMemcachedClientBuilder implements MemcachedClientBuilder {
 
   /*
    * (non-Javadoc)
-   * 
+   *
    * @see net.rubyeye.xmemcached.MemcachedClientBuilder#setConfiguration(com.google
    * .code.yanf4j.config.Configuration)
    */
@@ -308,7 +308,7 @@ public class XMemcachedClientBuilder implements MemcachedClientBuilder {
 
   /*
    * (non-Javadoc)
-   * 
+   *
    * @see net.rubyeye.xmemcached.MemcachedClientBuilder#build()
    */
   public MemcachedClient build() throws IOException {
@@ -362,7 +362,7 @@ public class XMemcachedClientBuilder implements MemcachedClientBuilder {
 
   /*
    * (non-Javadoc)
-   * 
+   *
    * @see net.rubyeye.xmemcached.MemcachedClientBuilder#setTranscoder(transcoder)
    */
   public void setTranscoder(Transcoder transcoder) {
@@ -378,7 +378,7 @@ public class XMemcachedClientBuilder implements MemcachedClientBuilder {
 
   /*
    * (non-Javadoc)
-   * 
+   *
    * @see net.rubyeye.xmemcached.MemcachedClientBuilder#setKeyProvider()
    */
   public void setKeyProvider(KeyProvider keyProvider) {
@@ -389,7 +389,7 @@ public class XMemcachedClientBuilder implements MemcachedClientBuilder {
 
   /*
    * (non-Javadoc)
-   * 
+   *
    * @see net.rubyeye.xmemcached.MemcachedClientBuilder#addAuthInfo()
    */
   public void addAuthInfo(InetSocketAddress address, AuthInfo authInfo) {
@@ -410,7 +410,7 @@ public class XMemcachedClientBuilder implements MemcachedClientBuilder {
 
   /*
    * (non-Javadoc)
-   * 
+   *
    * @see net.rubyeye.xmemcached.MemcachedClientBuilder#setName()
    */
   public void setName(String name) {

--- a/src/main/java/net/rubyeye/xmemcached/auth/AuthMemcachedConnectListener.java
+++ b/src/main/java/net/rubyeye/xmemcached/auth/AuthMemcachedConnectListener.java
@@ -10,9 +10,9 @@ import net.rubyeye.xmemcached.networking.MemcachedSessionConnectListener;
 
 /**
  * Client state listener for auth
- * 
+ *
  * @author dennis
- * 
+ *
  */
 public class AuthMemcachedConnectListener implements MemcachedSessionConnectListener {
 

--- a/src/main/java/net/rubyeye/xmemcached/auth/AuthMemcachedConnectListener.java
+++ b/src/main/java/net/rubyeye/xmemcached/auth/AuthMemcachedConnectListener.java
@@ -7,6 +7,7 @@ import net.rubyeye.xmemcached.XMemcachedClient;
 import net.rubyeye.xmemcached.impl.MemcachedTCPSession;
 import net.rubyeye.xmemcached.networking.MemcachedSession;
 import net.rubyeye.xmemcached.networking.MemcachedSessionConnectListener;
+import net.rubyeye.xmemcached.utils.AddrUtil;
 
 /**
  * Client state listener for auth
@@ -18,9 +19,10 @@ public class AuthMemcachedConnectListener implements MemcachedSessionConnectList
 
   public void onConnect(MemcachedSession session, MemcachedClient client) {
     MemcachedTCPSession tcpSession = (MemcachedTCPSession) session;
-    Map<InetSocketAddress, AuthInfo> authInfoMap = client.getAuthInfoMap();
+    Map<String, AuthInfo> authInfoMap = client.getAuthInfoStringMap();
     if (authInfoMap != null) {
-      AuthInfo authInfo = authInfoMap.get(tcpSession.getRemoteSocketAddress());
+      AuthInfo authInfo =
+          authInfoMap.get(AddrUtil.getServerString(tcpSession.getRemoteSocketAddress()));
       if (authInfo != null) {
         XMemcachedClient xMemcachedClient = (XMemcachedClient) client;
         AuthTask task = new AuthTask(authInfo, xMemcachedClient.getCommandFactory(), tcpSession);

--- a/src/main/java/net/rubyeye/xmemcached/utils/AddrUtil.java
+++ b/src/main/java/net/rubyeye/xmemcached/utils/AddrUtil.java
@@ -33,7 +33,7 @@ public class AddrUtil {
    * InetSocketAddress instances suitable for instantiating a MemcachedClient,map's key is the main
    * memcached node,and value is the standby node for main node. Note that colon-delimited IPv6 is
    * also supported. For example: ::1:11211
-   * 
+   *
    * @param s
    * @return
    */
@@ -83,7 +83,7 @@ public class AddrUtil {
   /**
    * Split a string in the form of "host:port host2:port" into a List of InetSocketAddress instances
    * suitable for instantiating a MemcachedClient.
-   * 
+   *
    * Note that colon-delimited IPv6 is also supported. For example: ::1:11211
    */
   public static List<InetSocketAddress> getAddresses(String s) {
@@ -131,7 +131,7 @@ public class AddrUtil {
 
   /**
    * System property to control shutdown hook, issue #44
-   * 
+   *
    * @since 2.0.1
    */
   public static boolean isEnableShutDownHook() {

--- a/src/main/java/net/rubyeye/xmemcached/utils/AddrUtil.java
+++ b/src/main/java/net/rubyeye/xmemcached/utils/AddrUtil.java
@@ -137,4 +137,11 @@ public class AddrUtil {
   public static boolean isEnableShutDownHook() {
     return Boolean.valueOf(System.getProperty("xmemcached.shutdown.hook.enable", "false"));
   }
+
+  /**
+   * Create an unresolved server string (hostname:port) from an InetSocketAddress.
+   */
+  public static final String getServerString(InetSocketAddress addr) {
+    return addr.getHostString() + ":" + Integer.toString(addr.getPort());
+  }
 }


### PR DESCRIPTION
This fixes #68

The problem was the the `AuthInfoMap` stores an `AuthInfo` for a server's `InetSocketAddress`. Unfortunately, the `InetSocketAddress` hash is based on the resolved IP which can change. For this reason I changed the `AuthInfoMap` to store the `AuthInfo` based on the servers (hostname:port) string.

Note, I tried to fix this problem without changing any public interface but I don't like it. I could also change the `MemcachedClient.getAuthInfoMap()` from `public Map<InetSocketAddress, AuthInfo> getAuthInfoMap();` to `public Map<String, AuthInfo> getAuthInfoMap();` instead. This would be a bit nicer but change the interface. What do you think?

Review by commit. The first commit only removes trailing whitespaces. The code changes are all in the second commit.