### PR TITLE
support cache dump in text protocol

### DIFF
--- a/src/main/java/net/rubyeye/xmemcached/command/TextCommandFactory.java
+++ b/src/main/java/net/rubyeye/xmemcached/command/TextCommandFactory.java
@@ -13,6 +13,7 @@ import net.rubyeye.xmemcached.command.text.TextGetMultiCommand;
 import net.rubyeye.xmemcached.command.text.TextGetOneCommand;
 import net.rubyeye.xmemcached.command.text.TextIncrDecrCommand;
 import net.rubyeye.xmemcached.command.text.TextQuitCommand;
+import net.rubyeye.xmemcached.command.text.TextStatsCachedumpCommand;
 import net.rubyeye.xmemcached.command.text.TextStatsCommand;
 import net.rubyeye.xmemcached.command.text.TextStoreCommand;
 import net.rubyeye.xmemcached.command.text.TextTouchCommand;
@@ -24,9 +25,9 @@ import net.rubyeye.xmemcached.utils.Protocol;
 
 /**
  * Command Factory for creating text protocol commands.
- * 
+ *
  * @author dennis
- * 
+ *
  */
 public class TextCommandFactory implements CommandFactory {
 
@@ -69,7 +70,7 @@ public class TextCommandFactory implements CommandFactory {
 
   /**
    * Create verbosity command
-   * 
+   *
    * @param latch
    * @param level
    * @param noreply
@@ -82,12 +83,23 @@ public class TextCommandFactory implements CommandFactory {
   /*
    * (non-Javadoc)
    * 
-   * @seenet.rubyeye.xmemcached.CommandFactory#createStatsCommand(java.net. InetSocketAddress,
+   * @seenet.rubyeye.xmemcached.CommandFactory#createStatsCommand(java.net.InetSocketAddress,
    * java.util.concurrent.CountDownLatch)
    */
   public final Command createStatsCommand(InetSocketAddress server, CountDownLatch latch,
       String itemName) {
     return new TextStatsCommand(server, latch, itemName);
+  }
+
+  /*
+  * (non-Javadoc)
+  *
+  * @seenet.rubyeye.xmemcached.CommandFactory#createStatsCachedumpCommand(java.net.InetSocketAddress,
+  * java.util.concurrent.CountDownLatch, int, int)
+  */
+  public final Command createStatsCachedumpCommand(InetSocketAddress server, CountDownLatch latch,
+      int slabId, int limit) {
+    return new TextStatsCachedumpCommand(server, latch, slabId, limit);
   }
 
   /*

--- a/src/main/java/net/rubyeye/xmemcached/command/text/TextStatsCachedumpCommand.java
+++ b/src/main/java/net/rubyeye/xmemcached/command/text/TextStatsCachedumpCommand.java
@@ -1,0 +1,43 @@
+package net.rubyeye.xmemcached.command.text;
+
+import java.util.HashMap;
+import net.rubyeye.xmemcached.impl.MemcachedTCPSession;
+import net.rubyeye.xmemcached.utils.ByteUtils;
+import java.net.InetSocketAddress;
+import java.nio.ByteBuffer;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class TextStatsCachedumpCommand extends TextStatsCommand {
+
+  static Pattern itemPattern =
+      Pattern.compile("ITEM (?<key>[^ ]+) \\[(?<size>\\d+) b; (?<expire>\\d+) s\\]");
+
+  public TextStatsCachedumpCommand(InetSocketAddress server, CountDownLatch latch, int slabId,
+      int limit) {
+    super(server, latch, String.format("cachedump %s %s", slabId, limit));
+    this.result = new HashMap<String, Integer[]>();
+  }
+
+  @Override
+  public final boolean decode(MemcachedTCPSession session, ByteBuffer buffer) {
+    String line = null;
+    while ((line = ByteUtils.nextLine(buffer)) != null) {
+      if (line.equals("END")) { // at the end
+        return super.done(session);
+      } else if (line.startsWith("ITEM")) {
+        Matcher m = itemPattern.matcher(line);
+        if (m.find()) {
+          ((Map<String, Integer[]>) getResult())
+              .put(m.group("key"), new Integer[]{Integer.parseInt(m.group("size")),
+                  Integer.parseInt(m.group("expire"))});
+        }
+      } else {
+        return decodeError(line);
+      }
+    }
+    return false;
+  }
+}

--- a/src/main/java/net/rubyeye/xmemcached/command/text/TextStatsCommand.java
+++ b/src/main/java/net/rubyeye/xmemcached/command/text/TextStatsCommand.java
@@ -67,7 +67,7 @@ public class TextStatsCommand extends Command implements ServerAddressAware {
 
   @Override
   @SuppressWarnings("unchecked")
-  public final boolean decode(MemcachedTCPSession session, ByteBuffer buffer) {
+  public boolean decode(MemcachedTCPSession session, ByteBuffer buffer) {
     String line = null;
     while ((line = ByteUtils.nextLine(buffer)) != null) {
       if (line.equals("END")) { // at the end
@@ -83,7 +83,7 @@ public class TextStatsCommand extends Command implements ServerAddressAware {
     return false;
   }
 
-  private final boolean done(MemcachedSession session) {
+  protected final boolean done(MemcachedSession session) {
     countDownLatch();
     return true;
   }


### PR DESCRIPTION
`cache dump` is useful to implement list-keys, more refer:
- https://stackoverflow.com/questions/19560150/get-all-keys-set-in-memcached

Currently `TextStatsCommand` only keep the first three items of response split by ` `, which isn't suitable for cache dump command.