### PR TITLE
Add AddressMemcachedSessionComparator

### DIFF
--- a/src/main/java/net/rubyeye/xmemcached/MemcachedClientBuilder.java
+++ b/src/main/java/net/rubyeye/xmemcached/MemcachedClientBuilder.java
@@ -32,6 +32,19 @@ public interface MemcachedClientBuilder {
    */
   public void setSessionLocator(MemcachedSessionLocator sessionLocator);
 
+  /**
+   * 
+   * @return net.rubyeye.xmemcached.MemcachedSessionComparator
+   */
+  public MemcachedSessionComparator getSessionComparator();
+
+  /**
+  * Set the XmemcachedClient's session comparator.Use IndexMemcachedSessionComparator by default.
+  * 
+  * @param sessionComparator
+  */
+  public void setSessionComparator(MemcachedSessionComparator sessionComparator);
+
   public BufferAllocator getBufferAllocator();
 
   /**

--- a/src/main/java/net/rubyeye/xmemcached/MemcachedSessionComparator.java
+++ b/src/main/java/net/rubyeye/xmemcached/MemcachedSessionComparator.java
@@ -1,0 +1,28 @@
+/**
+ * Copyright [2009-2010] [dennis zhuang(killme2008@gmail.com)] Licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in compliance with the License. You
+ * may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0 Unless required by
+ * applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
+ * the License for the specific language governing permissions and limitations under the License
+ */
+package net.rubyeye.xmemcached;
+
+import java.util.Comparator;
+import com.google.code.yanf4j.core.Session;
+
+/**
+ * Session comparator.
+ * 
+ * @author Jungsub Shin
+ * 
+ */
+public interface MemcachedSessionComparator extends Comparator<Session> {
+  /**
+   * Returns a session by special key.
+   * 
+   * @param key
+   * @return
+   */
+  public int compare(Session o1, Session o2);
+}

--- a/src/main/java/net/rubyeye/xmemcached/XMemcachedClientBuilder.java
+++ b/src/main/java/net/rubyeye/xmemcached/XMemcachedClientBuilder.java
@@ -13,6 +13,7 @@ import net.rubyeye.xmemcached.buffer.SimpleBufferAllocator;
 import net.rubyeye.xmemcached.command.TextCommandFactory;
 import net.rubyeye.xmemcached.impl.ArrayMemcachedSessionLocator;
 import net.rubyeye.xmemcached.impl.DefaultKeyProvider;
+import net.rubyeye.xmemcached.impl.IndexMemcachedSessionComparator;
 import net.rubyeye.xmemcached.impl.RandomMemcachedSessionLocaltor;
 import net.rubyeye.xmemcached.transcoders.SerializingTranscoder;
 import net.rubyeye.xmemcached.transcoders.Transcoder;
@@ -35,6 +36,7 @@ public class XMemcachedClientBuilder implements MemcachedClientBuilder {
   private static final Logger log = LoggerFactory.getLogger(XMemcachedClientBuilder.class);
 
   protected MemcachedSessionLocator sessionLocator = new ArrayMemcachedSessionLocator();
+  protected MemcachedSessionComparator sessionComparator = new IndexMemcachedSessionComparator();
   protected BufferAllocator bufferAllocator = new SimpleBufferAllocator();
   protected Configuration configuration = getDefaultConfiguration();
   protected Map<InetSocketAddress, InetSocketAddress> addressMap =
@@ -268,6 +270,28 @@ public class XMemcachedClientBuilder implements MemcachedClientBuilder {
   /*
    * (non-Javadoc)
    *
+   * @see net.rubyeye.xmemcached.MemcachedClientBuilder#getSessionComparator()
+   */
+  public MemcachedSessionComparator getSessionComparator() {
+    return this.sessionComparator;
+  }
+
+  /*
+   * (non-Javadoc)
+   *
+   * @see net.rubyeye.xmemcached.MemcachedClientBuilder#setSessionComparator(net. rubyeye
+   * .xmemcached.MemcachedSessionComparator)
+   */
+  public void setSessionComparator(MemcachedSessionComparator sessionComparator) {
+    if (sessionComparator == null) {
+      throw new IllegalArgumentException("Null SessionComparator");
+    }
+    this.sessionComparator = sessionComparator;
+  }
+
+  /*
+   * (non-Javadoc)
+   *
    * @see net.rubyeye.xmemcached.MemcachedClientBuilder#getBufferAllocator()
    */
   public BufferAllocator getBufferAllocator() {
@@ -321,10 +345,10 @@ public class XMemcachedClientBuilder implements MemcachedClientBuilder {
       }
     }
     if (this.weights == null) {
-      memcachedClient = new XMemcachedClient(this.sessionLocator, this.bufferAllocator,
-          this.configuration, this.socketOptions, this.commandFactory, this.transcoder,
-          this.addressMap, this.stateListeners, this.authInfoMap, this.connectionPoolSize,
-          this.connectTimeout, this.name, this.failureMode);
+      memcachedClient = new XMemcachedClient(this.sessionLocator, this.sessionComparator,
+          this.bufferAllocator, this.configuration, this.socketOptions, this.commandFactory,
+          this.transcoder, this.addressMap, this.stateListeners, this.authInfoMap,
+          this.connectionPoolSize, this.connectTimeout, this.name, this.failureMode);
 
     } else {
       if (this.addressMap == null) {
@@ -333,9 +357,9 @@ public class XMemcachedClientBuilder implements MemcachedClientBuilder {
       if (this.addressMap.size() > this.weights.length) {
         throw new IllegalArgumentException("Weights Array's length is less than server's number");
       }
-      memcachedClient = new XMemcachedClient(this.sessionLocator, this.bufferAllocator,
-          this.configuration, this.socketOptions, this.commandFactory, this.transcoder,
-          this.addressMap, this.weights, this.stateListeners, this.authInfoMap,
+      memcachedClient = new XMemcachedClient(this.sessionLocator, this.sessionComparator,
+          this.bufferAllocator, this.configuration, this.socketOptions, this.commandFactory,
+          this.transcoder, this.addressMap, this.weights, this.stateListeners, this.authInfoMap,
           this.connectionPoolSize, this.connectTimeout, this.name, this.failureMode);
     }
     this.configureClient(memcachedClient);

--- a/src/main/java/net/rubyeye/xmemcached/aws/AWSElasticCacheClient.java
+++ b/src/main/java/net/rubyeye/xmemcached/aws/AWSElasticCacheClient.java
@@ -15,6 +15,7 @@ import com.google.code.yanf4j.core.Session;
 import com.google.code.yanf4j.core.SocketOption;
 import net.rubyeye.xmemcached.CommandFactory;
 import net.rubyeye.xmemcached.MemcachedClientStateListener;
+import net.rubyeye.xmemcached.MemcachedSessionComparator;
 import net.rubyeye.xmemcached.MemcachedSessionLocator;
 import net.rubyeye.xmemcached.XMemcachedClient;
 import net.rubyeye.xmemcached.XMemcachedClientBuilder;
@@ -25,6 +26,7 @@ import net.rubyeye.xmemcached.command.Command;
 import net.rubyeye.xmemcached.command.TextCommandFactory;
 import net.rubyeye.xmemcached.exception.MemcachedException;
 import net.rubyeye.xmemcached.impl.ArrayMemcachedSessionLocator;
+import net.rubyeye.xmemcached.impl.IndexMemcachedSessionComparator;
 import net.rubyeye.xmemcached.transcoders.SerializingTranscoder;
 import net.rubyeye.xmemcached.transcoders.Transcoder;
 import net.rubyeye.xmemcached.utils.InetSocketAddressWrapper;
@@ -184,8 +186,8 @@ public class AWSElasticCacheClient extends XMemcachedClient implements ConfigUpd
   @SuppressWarnings("unchecked")
   public AWSElasticCacheClient(List<InetSocketAddress> addrs, long pollConfigIntervalMills,
       CommandFactory commandFactory) throws IOException {
-    this(new ArrayMemcachedSessionLocator(), new SimpleBufferAllocator(),
-        XMemcachedClientBuilder.getDefaultConfiguration(),
+    this(new ArrayMemcachedSessionLocator(), new IndexMemcachedSessionComparator(),
+        new SimpleBufferAllocator(), XMemcachedClientBuilder.getDefaultConfiguration(),
         XMemcachedClientBuilder.getDefaultSocketOptions(), new TextCommandFactory(),
         new SerializingTranscoder(), (List<MemcachedClientStateListener>) Collections.EMPTY_LIST,
         (Map<InetSocketAddress, AuthInfo>) Collections.EMPTY_MAP, 1,
@@ -203,13 +205,13 @@ public class AWSElasticCacheClient extends XMemcachedClient implements ConfigUpd
     return m;
   }
 
-  AWSElasticCacheClient(MemcachedSessionLocator locator, BufferAllocator allocator,
-      Configuration conf, Map<SocketOption, Object> socketOptions, CommandFactory commandFactory,
-      Transcoder transcoder, List<MemcachedClientStateListener> stateListeners,
-      Map<InetSocketAddress, AuthInfo> map, int poolSize, long connectTimeout, String name,
-      boolean failureMode, List<InetSocketAddress> configAddrs, long pollConfigIntervalMills)
-      throws IOException {
-    super(locator, allocator, conf, socketOptions, commandFactory, transcoder,
+  AWSElasticCacheClient(MemcachedSessionLocator locator, MemcachedSessionComparator comparator,
+      BufferAllocator allocator, Configuration conf, Map<SocketOption, Object> socketOptions,
+      CommandFactory commandFactory, Transcoder transcoder,
+      List<MemcachedClientStateListener> stateListeners, Map<InetSocketAddress, AuthInfo> map,
+      int poolSize, long connectTimeout, String name, boolean failureMode,
+      List<InetSocketAddress> configAddrs, long pollConfigIntervalMills) throws IOException {
+    super(locator, comparator, allocator, conf, socketOptions, commandFactory, transcoder,
         getAddressMapFromConfigAddrs(configAddrs), stateListeners, map, poolSize, connectTimeout,
         name, failureMode);
     if (pollConfigIntervalMills <= 0) {

--- a/src/main/java/net/rubyeye/xmemcached/aws/AWSElasticCacheClientBuilder.java
+++ b/src/main/java/net/rubyeye/xmemcached/aws/AWSElasticCacheClientBuilder.java
@@ -96,10 +96,11 @@ public class AWSElasticCacheClientBuilder extends XMemcachedClientBuilder {
   @Override
   public AWSElasticCacheClient build() throws IOException {
 
-    AWSElasticCacheClient memcachedClient = new AWSElasticCacheClient(this.sessionLocator,
-        this.bufferAllocator, this.configuration, this.socketOptions, this.commandFactory,
-        this.transcoder, this.stateListeners, this.authInfoMap, this.connectionPoolSize,
-        this.connectTimeout, this.name, this.failureMode, configAddrs, this.pollConfigIntervalMs);
+    AWSElasticCacheClient memcachedClient =
+        new AWSElasticCacheClient(this.sessionLocator, this.sessionComparator, this.bufferAllocator,
+            this.configuration, this.socketOptions, this.commandFactory, this.transcoder,
+            this.stateListeners, this.authInfoMap, this.connectionPoolSize, this.connectTimeout,
+            this.name, this.failureMode, configAddrs, this.pollConfigIntervalMs);
     this.configureClient(memcachedClient);
 
     return memcachedClient;

--- a/src/main/java/net/rubyeye/xmemcached/impl/AddressMemcachedSessionComparator.java
+++ b/src/main/java/net/rubyeye/xmemcached/impl/AddressMemcachedSessionComparator.java
@@ -1,0 +1,31 @@
+package net.rubyeye.xmemcached.impl;
+
+import java.io.Serializable;
+import net.rubyeye.xmemcached.MemcachedSessionComparator;
+import net.rubyeye.xmemcached.networking.MemcachedSession;
+import com.google.code.yanf4j.core.Session;
+
+/**
+ * Connection comparator,compare with Address
+ * 
+ * @author Jungsub Shin
+ * 
+ */
+public class AddressMemcachedSessionComparator implements MemcachedSessionComparator, Serializable {
+  static final long serialVersionUID = -1L;
+
+  public int compare(Session o1, Session o2) {
+    MemcachedSession session1 = (MemcachedSession) o1;
+    MemcachedSession session2 = (MemcachedSession) o2;
+    if (session1 == null || session1.getInetSocketAddressWrapper() == null
+        || session1.getInetSocketAddressWrapper().getInetSocketAddress() == null) {
+      return -1;
+    }
+    if (session2 == null || session2.getInetSocketAddressWrapper() == null
+        || session2.getInetSocketAddressWrapper().getInetSocketAddress() == null) {
+      return 1;
+    }
+    return session1.getInetSocketAddressWrapper().getInetSocketAddress().toString()
+        .compareTo(session2.getInetSocketAddressWrapper().getInetSocketAddress().toString());
+  }
+}

--- a/src/main/java/net/rubyeye/xmemcached/impl/IndexMemcachedSessionComparator.java
+++ b/src/main/java/net/rubyeye/xmemcached/impl/IndexMemcachedSessionComparator.java
@@ -1,7 +1,7 @@
 package net.rubyeye.xmemcached.impl;
 
 import java.io.Serializable;
-import java.util.Comparator;
+import net.rubyeye.xmemcached.MemcachedSessionComparator;
 import net.rubyeye.xmemcached.networking.MemcachedSession;
 import com.google.code.yanf4j.core.Session;
 
@@ -11,7 +11,7 @@ import com.google.code.yanf4j.core.Session;
  * @author dennis
  * 
  */
-public class MemcachedSessionComparator implements Comparator<Session>, Serializable {
+public class IndexMemcachedSessionComparator implements MemcachedSessionComparator, Serializable {
   static final long serialVersionUID = -1L;
 
   public int compare(Session o1, Session o2) {

--- a/src/main/java/net/rubyeye/xmemcached/impl/MemcachedConnector.java
+++ b/src/main/java/net/rubyeye/xmemcached/impl/MemcachedConnector.java
@@ -34,6 +34,7 @@ import net.rubyeye.xmemcached.CommandFactory;
 import net.rubyeye.xmemcached.FlowControl;
 import net.rubyeye.xmemcached.MemcachedClient;
 import net.rubyeye.xmemcached.MemcachedOptimizer;
+import net.rubyeye.xmemcached.MemcachedSessionComparator;
 import net.rubyeye.xmemcached.MemcachedSessionLocator;
 import net.rubyeye.xmemcached.buffer.BufferAllocator;
 import net.rubyeye.xmemcached.command.Command;
@@ -89,6 +90,10 @@ public class MemcachedConnector extends SocketChannelController implements Conne
 
   public void setSessionLocator(MemcachedSessionLocator sessionLocator) {
     this.sessionLocator = sessionLocator;
+  }
+
+  public void setSessionComparator(MemcachedSessionComparator sessionComparator) {
+    this.sessionComparator = sessionComparator;
   }
 
   /**
@@ -205,6 +210,7 @@ public class MemcachedConnector extends SocketChannelController implements Conne
   }
 
   protected MemcachedSessionLocator sessionLocator;
+  protected MemcachedSessionComparator sessionComparator;
 
   protected final ConcurrentHashMap<InetSocketAddress, Queue<Session>> sessionMap =
       new ConcurrentHashMap<InetSocketAddress, Queue<Session>>();
@@ -329,9 +335,6 @@ public class MemcachedConnector extends SocketChannelController implements Conne
       }
     }
   }
-
-  private static final MemcachedSessionComparator sessionComparator =
-      new MemcachedSessionComparator();
 
   public final void updateSessions() {
     Collection<Queue<Session>> sessionCollection = this.sessionMap.values();
@@ -576,10 +579,11 @@ public class MemcachedConnector extends SocketChannelController implements Conne
   }
 
   public MemcachedConnector(Configuration configuration, MemcachedSessionLocator locator,
-      BufferAllocator allocator, CommandFactory commandFactory, int poolSize,
-      int maxQueuedNoReplyOperations) {
+      MemcachedSessionComparator comparator, BufferAllocator allocator,
+      CommandFactory commandFactory, int poolSize, int maxQueuedNoReplyOperations) {
     super(configuration, null);
     this.sessionLocator = locator;
+    this.sessionComparator = comparator;
     this.protocol = commandFactory.getProtocol();
     this.addStateListener(new InnerControllerStateListener());
     this.updateSessions();

--- a/src/main/java/net/rubyeye/xmemcached/networking/Connector.java
+++ b/src/main/java/net/rubyeye/xmemcached/networking/Connector.java
@@ -24,6 +24,7 @@ import java.util.Queue;
 import java.util.Set;
 import java.util.concurrent.Future;
 import net.rubyeye.xmemcached.FlowControl;
+import net.rubyeye.xmemcached.MemcachedSessionComparator;
 import net.rubyeye.xmemcached.MemcachedSessionLocator;
 import net.rubyeye.xmemcached.buffer.BufferAllocator;
 import net.rubyeye.xmemcached.command.Command;
@@ -79,6 +80,8 @@ public interface Connector extends Controller {
   public void updateSessions();
 
   public void setSessionLocator(MemcachedSessionLocator sessionLocator);
+
+  public void setSessionComparator(MemcachedSessionComparator sessionComparator);
 
   /**
    * Make all connection sending a quit command to memcached

--- a/src/main/java/net/rubyeye/xmemcached/utils/XMemcachedClientFactoryBean.java
+++ b/src/main/java/net/rubyeye/xmemcached/utils/XMemcachedClientFactoryBean.java
@@ -25,6 +25,7 @@ import net.rubyeye.xmemcached.CommandFactory;
 import net.rubyeye.xmemcached.KeyProvider;
 import net.rubyeye.xmemcached.MemcachedClient;
 import net.rubyeye.xmemcached.MemcachedClientBuilder;
+import net.rubyeye.xmemcached.MemcachedSessionComparator;
 import net.rubyeye.xmemcached.MemcachedSessionLocator;
 import net.rubyeye.xmemcached.XMemcachedClientBuilder;
 import net.rubyeye.xmemcached.auth.AuthInfo;
@@ -33,6 +34,7 @@ import net.rubyeye.xmemcached.buffer.SimpleBufferAllocator;
 import net.rubyeye.xmemcached.command.TextCommandFactory;
 import net.rubyeye.xmemcached.impl.ArrayMemcachedSessionLocator;
 import net.rubyeye.xmemcached.impl.DefaultKeyProvider;
+import net.rubyeye.xmemcached.impl.IndexMemcachedSessionComparator;
 import net.rubyeye.xmemcached.transcoders.SerializingTranscoder;
 import net.rubyeye.xmemcached.transcoders.Transcoder;
 import org.springframework.beans.factory.FactoryBean;
@@ -47,6 +49,7 @@ import com.google.code.yanf4j.config.Configuration;
 public class XMemcachedClientFactoryBean implements FactoryBean {
 
   private MemcachedSessionLocator sessionLocator = new ArrayMemcachedSessionLocator();
+  private MemcachedSessionComparator sessionComparator = new IndexMemcachedSessionComparator();
   private BufferAllocator bufferAllocator = new SimpleBufferAllocator();
   private String servers;
   private List<Integer> weights;
@@ -167,6 +170,10 @@ public class XMemcachedClientFactoryBean implements FactoryBean {
     this.sessionLocator = sessionLocator;
   }
 
+  public void setSessionComparator(MemcachedSessionComparator sessionComparator) {
+    this.sessionComparator = sessionComparator;
+  }
+
   public void setBufferAllocator(BufferAllocator bufferAllocator) {
     this.bufferAllocator = bufferAllocator;
   }
@@ -190,6 +197,10 @@ public class XMemcachedClientFactoryBean implements FactoryBean {
 
   public MemcachedSessionLocator getSessionLocator() {
     return this.sessionLocator;
+  }
+
+  public MemcachedSessionComparator getSessionComparator() {
+    return this.sessionComparator;
   }
 
   public BufferAllocator getBufferAllocator() {
@@ -253,6 +264,7 @@ public class XMemcachedClientFactoryBean implements FactoryBean {
     builder.setConfiguration(this.configuration);
     builder.setBufferAllocator(this.bufferAllocator);
     builder.setSessionLocator(this.sessionLocator);
+    builder.setSessionComparator(this.sessionComparator);
     builder.setTranscoder(this.transcoder);
     builder.setCommandFactory(this.commandFactory);
     builder.setConnectionPoolSize(this.connectionPoolSize);
@@ -297,6 +309,9 @@ public class XMemcachedClientFactoryBean implements FactoryBean {
     }
     if (this.sessionLocator == null) {
       throw new NullPointerException("Null MemcachedSessionLocator");
+    }
+    if (this.sessionComparator == null) {
+      throw new NullPointerException("Null MemcachedSessionComparator");
     }
     if (this.configuration == null) {
       throw new NullPointerException("Null networking configuration");

--- a/src/test/java/net/rubyeye/xmemcached/test/unittest/impl/IndexMemcachedSessionComparatorUnitTest.java
+++ b/src/test/java/net/rubyeye/xmemcached/test/unittest/impl/IndexMemcachedSessionComparatorUnitTest.java
@@ -1,0 +1,272 @@
+package net.rubyeye.xmemcached.test.unittest.impl;
+
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.nio.ByteOrder;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.Future;
+import junit.framework.TestCase;
+import net.rubyeye.xmemcached.buffer.BufferAllocator;
+import net.rubyeye.xmemcached.impl.IndexMemcachedSessionComparator;
+import net.rubyeye.xmemcached.networking.MemcachedSession;
+import net.rubyeye.xmemcached.utils.InetSocketAddressWrapper;
+import com.google.code.yanf4j.core.Handler;
+import com.google.code.yanf4j.core.Session;
+import com.google.code.yanf4j.core.CodecFactory.Decoder;
+import com.google.code.yanf4j.core.CodecFactory.Encoder;
+
+public class IndexMemcachedSessionComparatorUnitTest extends TestCase {
+  static private class MockSession implements MemcachedSession, Session {
+    private final int order;
+
+    public InetSocketAddressWrapper getInetSocketAddressWrapper() {
+      return new InetSocketAddressWrapper(null, this.order, 0, null);
+    }
+
+    public MockSession(int order) {
+      super();
+      this.order = order;
+    }
+
+    public void quit() {
+      // TODO Auto-generated method stub
+
+    }
+
+    public boolean isAuthFailed() {
+      // TODO Auto-generated method stub
+      return false;
+    }
+
+    public void setAuthFailed(boolean authFailed) {
+      // TODO Auto-generated method stub
+
+    }
+
+    public Future<Boolean> asyncWrite(Object packet) {
+      // TODO Auto-generated method stub
+      return null;
+    }
+
+    public void clearAttributes() {
+      // TODO Auto-generated method stub
+
+    }
+
+    public void destroy() {
+      // TODO Auto-generated method stub
+
+    }
+
+    public void close() {
+      // TODO Auto-generated method stub
+
+    }
+
+    public void flush() {
+      // TODO Auto-generated method stub
+
+    }
+
+    public Object getAttribute(String key) {
+      // TODO Auto-generated method stub
+      return null;
+    }
+
+    public Decoder getDecoder() {
+      // TODO Auto-generated method stub
+      return null;
+    }
+
+    public Encoder getEncoder() {
+      // TODO Auto-generated method stub
+      return null;
+    }
+
+    public Handler getHandler() {
+      // TODO Auto-generated method stub
+      return null;
+    }
+
+    public long getLastOperationTimeStamp() {
+      // TODO Auto-generated method stub
+      return 0;
+    }
+
+    public InetAddress getLocalAddress() {
+      // TODO Auto-generated method stub
+      return null;
+    }
+
+    public ByteOrder getReadBufferByteOrder() {
+      // TODO Auto-generated method stub
+      return null;
+    }
+
+    public InetSocketAddress getRemoteSocketAddress() {
+      // TODO Auto-generated method stub
+      return null;
+    }
+
+    public long getScheduleWritenBytes() {
+      // TODO Auto-generated method stub
+      return 0;
+    }
+
+    public long getSessionIdleTimeout() {
+      // TODO Auto-generated method stub
+      return 0;
+    }
+
+    public long getSessionTimeout() {
+      // TODO Auto-generated method stub
+      return 0;
+    }
+
+    public boolean isClosed() {
+      // TODO Auto-generated method stub
+      return false;
+    }
+
+    public boolean isExpired() {
+      // TODO Auto-generated method stub
+      return false;
+    }
+
+    public boolean isHandleReadWriteConcurrently() {
+      // TODO Auto-generated method stub
+      return false;
+    }
+
+    public boolean isIdle() {
+      // TODO Auto-generated method stub
+      return false;
+    }
+
+    public boolean isLoopbackConnection() {
+      // TODO Auto-generated method stub
+      return false;
+    }
+
+    public boolean isUseBlockingRead() {
+      // TODO Auto-generated method stub
+      return false;
+    }
+
+    public boolean isUseBlockingWrite() {
+      // TODO Auto-generated method stub
+      return false;
+    }
+
+    public void removeAttribute(String key) {
+      // TODO Auto-generated method stub
+
+    }
+
+    public void setAttribute(String key, Object value) {
+      // TODO Auto-generated method stub
+
+    }
+
+    public Object setAttributeIfAbsent(String key, Object value) {
+      // TODO Auto-generated method stub
+      return null;
+    }
+
+    public void setDecoder(Decoder decoder) {
+      // TODO Auto-generated method stub
+
+    }
+
+    public void setEncoder(Encoder encoder) {
+      // TODO Auto-generated method stub
+
+    }
+
+    public void setHandleReadWriteConcurrently(boolean handleReadWriteConcurrently) {
+      // TODO Auto-generated method stub
+
+    }
+
+    public void setReadBufferByteOrder(ByteOrder readBufferByteOrder) {
+      // TODO Auto-generated method stub
+
+    }
+
+    public void setSessionIdleTimeout(long sessionIdleTimeout) {
+      // TODO Auto-generated method stub
+
+    }
+
+    public void setSessionTimeout(long sessionTimeout) {
+      // TODO Auto-generated method stub
+
+    }
+
+    public void setUseBlockingRead(boolean useBlockingRead) {
+      // TODO Auto-generated method stub
+
+    }
+
+    public void setUseBlockingWrite(boolean useBlockingWrite) {
+      // TODO Auto-generated method stub
+
+    }
+
+    public void start() {
+      // TODO Auto-generated method stub
+
+    }
+
+    public void write(Object packet) {
+      // TODO Auto-generated method stub
+
+    }
+
+    public int getOrder() {
+      return this.order;
+    }
+
+    public int getWeight() {
+      // TODO Auto-generated method stub
+      return 0;
+    }
+
+    public boolean isAllowReconnect() {
+      // TODO Auto-generated method stub
+      return false;
+    }
+
+    public void setAllowReconnect(boolean allow) {
+      // TODO Auto-generated method stub
+
+    }
+
+    public void setBufferAllocator(BufferAllocator allocator) {
+      // TODO Auto-generated method stub
+
+    }
+
+  }
+
+  public void testCompare() {
+
+    List<Session> sessionList = new ArrayList<Session>();
+    for (int i = 0; i < 100; i++) {
+      sessionList.add(new MockSession(i));
+    }
+    Collections.sort(sessionList, new IndexMemcachedSessionComparator());
+
+    for (int i = 0; i < sessionList.size(); i++) {
+      if (i < sessionList.size() - 1) {
+        int next = i + 1;
+        MockSession nextSession = (MockSession) sessionList.get(next);
+        MockSession currentSession = (MockSession) sessionList.get(i);
+        assertTrue(currentSession.getOrder() < nextSession.getOrder());
+      }
+    }
+
+  }
+}


### PR DESCRIPTION
Memecached cluster servers/client in container cluster such as k8s has the following characteristics.
* Servers can be added or deleted at any time.
* For client (App, Service) loadbalancing, the same client runs in the multiple containers. 
* To increase the client cache hit, it is recommended to use the same key/server Map.

Now xmemcached only supports index-based sorting of servers. Index-based sorting can not guarantee the same key/server map that works in multiple containers. To resolve the this issue, I added an address-based sorting method.

The modifications and additions are as follows.

* Rename MemcachedSessionComparator to IndexMemcachedSessionComparator
* Add MemcachedSessionComparator Interface
* Add AddressMemcachedSessionComparator