### PR TITLE
Allow disabling address resolution

### DIFF
--- a/src/main/java/net/rubyeye/xmemcached/MemcachedClient.java
+++ b/src/main/java/net/rubyeye/xmemcached/MemcachedClient.java
@@ -186,6 +186,13 @@ public interface MemcachedClient {
   public void removeServer(String hostList);
 
   /**
+   * Remove memcached server with the exact given address.
+   *
+   * @param address Resolved server address
+   */
+  public void removeServer(InetSocketAddress address);
+
+  /**
    * Set the nio's ByteBuffer Allocator,use SimpleBufferAllocator by default.
    *
    *

--- a/src/main/java/net/rubyeye/xmemcached/XMemcachedClientBuilder.java
+++ b/src/main/java/net/rubyeye/xmemcached/XMemcachedClientBuilder.java
@@ -73,6 +73,12 @@ public class XMemcachedClientBuilder implements MemcachedClientBuilder {
 
   protected long opTimeout = MemcachedClient.DEFAULT_OP_TIMEOUT;
 
+  protected boolean resolveInetAddresses = true;
+
+  public void doNotResolveInetAddresses() {
+    this.resolveInetAddresses = false;
+  }
+
   public long getOpTimeout() {
     return opTimeout;
   }
@@ -345,10 +351,11 @@ public class XMemcachedClientBuilder implements MemcachedClientBuilder {
       }
     }
     if (this.weights == null) {
-      memcachedClient = new XMemcachedClient(this.sessionLocator, this.sessionComparator,
-          this.bufferAllocator, this.configuration, this.socketOptions, this.commandFactory,
-          this.transcoder, this.addressMap, this.stateListeners, this.authInfoMap,
-          this.connectionPoolSize, this.connectTimeout, this.name, this.failureMode);
+      memcachedClient =
+          new XMemcachedClient(this.sessionLocator, this.sessionComparator, this.bufferAllocator,
+              this.configuration, this.socketOptions, this.commandFactory, this.transcoder,
+              this.addressMap, this.stateListeners, this.authInfoMap, this.connectionPoolSize,
+              this.connectTimeout, this.name, this.failureMode, this.resolveInetAddresses);
 
     } else {
       if (this.addressMap == null) {
@@ -360,7 +367,8 @@ public class XMemcachedClientBuilder implements MemcachedClientBuilder {
       memcachedClient = new XMemcachedClient(this.sessionLocator, this.sessionComparator,
           this.bufferAllocator, this.configuration, this.socketOptions, this.commandFactory,
           this.transcoder, this.addressMap, this.weights, this.stateListeners, this.authInfoMap,
-          this.connectionPoolSize, this.connectTimeout, this.name, this.failureMode);
+          this.connectionPoolSize, this.connectTimeout, this.name, this.failureMode,
+          this.resolveInetAddresses);
     }
     this.configureClient(memcachedClient);
     return memcachedClient;

--- a/src/main/java/net/rubyeye/xmemcached/XMemcachedClientBuilder.java
+++ b/src/main/java/net/rubyeye/xmemcached/XMemcachedClientBuilder.java
@@ -75,6 +75,14 @@ public class XMemcachedClientBuilder implements MemcachedClientBuilder {
 
   protected boolean resolveInetAddresses = true;
 
+  public boolean isResolveInetAddresses() {
+    return resolveInetAddresses;
+  }
+
+  public void setResolveInetAddresses(boolean resolveInetAddresses) {
+    this.resolveInetAddresses = resolveInetAddresses;
+  }
+
   public void doNotResolveInetAddresses() {
     this.resolveInetAddresses = false;
   }

--- a/src/main/java/net/rubyeye/xmemcached/aws/AWSElasticCacheClient.java
+++ b/src/main/java/net/rubyeye/xmemcached/aws/AWSElasticCacheClient.java
@@ -76,7 +76,7 @@ public class AWSElasticCacheClient extends XMemcachedClient implements ConfigUpd
     for (CacheNode node : addNodes) {
       try {
         this.connect(new InetSocketAddressWrapper(node.getInetSocketAddress(),
-            this.configPoller.getCacheNodeOrder(node), 1, null));
+            this.configPoller.getCacheNodeOrder(node), 1, null, this.resolveInetAddresses));
       } catch (IOException e) {
         log.error("Connect to " + node + "failed.", e);
       }
@@ -191,7 +191,7 @@ public class AWSElasticCacheClient extends XMemcachedClient implements ConfigUpd
         XMemcachedClientBuilder.getDefaultSocketOptions(), new TextCommandFactory(),
         new SerializingTranscoder(), (List<MemcachedClientStateListener>) Collections.EMPTY_LIST,
         (Map<InetSocketAddress, AuthInfo>) Collections.EMPTY_MAP, 1,
-        XMemcachedClient.DEFAULT_CONNECT_TIMEOUT, null, true, addrs, pollConfigIntervalMills);
+        XMemcachedClient.DEFAULT_CONNECT_TIMEOUT, null, true, true, addrs, pollConfigIntervalMills);
 
   }
 
@@ -210,10 +210,11 @@ public class AWSElasticCacheClient extends XMemcachedClient implements ConfigUpd
       CommandFactory commandFactory, Transcoder transcoder,
       List<MemcachedClientStateListener> stateListeners, Map<InetSocketAddress, AuthInfo> map,
       int poolSize, long connectTimeout, String name, boolean failureMode,
-      List<InetSocketAddress> configAddrs, long pollConfigIntervalMills) throws IOException {
+      boolean resolveInetAddresses, List<InetSocketAddress> configAddrs,
+      long pollConfigIntervalMills) throws IOException {
     super(locator, comparator, allocator, conf, socketOptions, commandFactory, transcoder,
         getAddressMapFromConfigAddrs(configAddrs), stateListeners, map, poolSize, connectTimeout,
-        name, failureMode);
+        name, failureMode, resolveInetAddresses);
     if (pollConfigIntervalMills <= 0) {
       throw new IllegalArgumentException("Invalid pollConfigIntervalMills value.");
     }

--- a/src/main/java/net/rubyeye/xmemcached/aws/AWSElasticCacheClientBuilder.java
+++ b/src/main/java/net/rubyeye/xmemcached/aws/AWSElasticCacheClientBuilder.java
@@ -96,11 +96,11 @@ public class AWSElasticCacheClientBuilder extends XMemcachedClientBuilder {
   @Override
   public AWSElasticCacheClient build() throws IOException {
 
-    AWSElasticCacheClient memcachedClient =
-        new AWSElasticCacheClient(this.sessionLocator, this.sessionComparator, this.bufferAllocator,
-            this.configuration, this.socketOptions, this.commandFactory, this.transcoder,
-            this.stateListeners, this.authInfoMap, this.connectionPoolSize, this.connectTimeout,
-            this.name, this.failureMode, configAddrs, this.pollConfigIntervalMs);
+    AWSElasticCacheClient memcachedClient = new AWSElasticCacheClient(this.sessionLocator,
+        this.sessionComparator, this.bufferAllocator, this.configuration, this.socketOptions,
+        this.commandFactory, this.transcoder, this.stateListeners, this.authInfoMap,
+        this.connectionPoolSize, this.connectTimeout, this.name, this.failureMode,
+        this.resolveInetAddresses, configAddrs, this.pollConfigIntervalMs);
     this.configureClient(memcachedClient);
 
     return memcachedClient;

--- a/src/main/java/net/rubyeye/xmemcached/utils/InetSocketAddressWrapper.java
+++ b/src/main/java/net/rubyeye/xmemcached/utils/InetSocketAddressWrapper.java
@@ -15,6 +15,7 @@ public class InetSocketAddressWrapper {
   private volatile String remoteAddressStr;
   private volatile String hostName;
   private volatile String mainNodeHostName;
+  private boolean resolve;
   /**
    * Main memcached node address,if this is a main node,then this value is null.
    */
@@ -22,11 +23,17 @@ public class InetSocketAddressWrapper {
 
   public InetSocketAddressWrapper(InetSocketAddress inetSocketAddress, int order, int weight,
       InetSocketAddress mainNodeAddress) {
+    this(inetSocketAddress, order, weight, mainNodeAddress, true);
+  }
+
+  public InetSocketAddressWrapper(InetSocketAddress inetSocketAddress, int order, int weight,
+      InetSocketAddress mainNodeAddress, boolean resolve) {
     super();
     setInetSocketAddress(inetSocketAddress);
     setMainNodeAddress(mainNodeAddress);
     this.order = order;
     this.weight = weight;
+    this.resolve = resolve;
   }
 
   public String getRemoteAddressStr() {
@@ -38,7 +45,7 @@ public class InetSocketAddressWrapper {
   }
 
   public final InetSocketAddress getInetSocketAddress() {
-    if (ByteUtils.isValidString(this.hostName)) {
+    if (resolve && ByteUtils.isValidString(this.hostName)) {
       // If it has a hostName, we try to resolve it again.
       return new InetSocketAddress(this.hostName, this.inetSocketAddress.getPort());
     } else {
@@ -64,7 +71,7 @@ public class InetSocketAddressWrapper {
 
   private final void setInetSocketAddress(InetSocketAddress inetSocketAddress) {
     this.inetSocketAddress = inetSocketAddress;
-    if (inetSocketAddress != null) {
+    if (resolve && inetSocketAddress != null) {
       this.hostName = inetSocketAddress.getHostName();
     }
   }
@@ -82,7 +89,7 @@ public class InetSocketAddressWrapper {
   }
 
   public InetSocketAddress getMainNodeAddress() {
-    if (ByteUtils.isValidString(this.mainNodeHostName)) {
+    if (resolve && ByteUtils.isValidString(this.mainNodeHostName)) {
       return new InetSocketAddress(this.mainNodeHostName, this.mainNodeAddress.getPort());
     } else {
       return this.mainNodeAddress;
@@ -91,7 +98,7 @@ public class InetSocketAddressWrapper {
 
   private void setMainNodeAddress(InetSocketAddress mainNodeAddress) {
     this.mainNodeAddress = mainNodeAddress;
-    if (mainNodeAddress != null) {
+    if (resolve && mainNodeAddress != null) {
       this.mainNodeHostName = mainNodeAddress.getHostName();
     }
   }


### PR DESCRIPTION
When client does DNS lookup by itself and provides raw IP addresses
to XMemcachedClient - it should be possible to disable any automatic
hostname resolution. Otherwise it might cause conflicts.

For the same purpose client should be able to remove a server using
raw address, not a host name. Exposed method should be renamed to
removeServer to be consistent with a complimentary pair of addServer
methods.