### PR TITLE
fix https://github.com/killme2008/xmemcached/issues/68 

### DIFF
--- a/src/main/java/net/rubyeye/xmemcached/utils/InetSocketAddressWrapper.java
+++ b/src/main/java/net/rubyeye/xmemcached/utils/InetSocketAddressWrapper.java
@@ -4,9 +4,9 @@ import java.net.InetSocketAddress;
 
 /**
  * InetSocketAddress wrapper,encapsulate an order number.
- * 
+ *
  * @author dennis
- * 
+ *
  */
 public class InetSocketAddressWrapper {
   private volatile InetSocketAddress inetSocketAddress;
@@ -29,11 +29,11 @@ public class InetSocketAddressWrapper {
   public InetSocketAddressWrapper(InetSocketAddress inetSocketAddress, int order, int weight,
       InetSocketAddress mainNodeAddress, boolean resolve) {
     super();
+    this.resolve = resolve;
     setInetSocketAddress(inetSocketAddress);
     setMainNodeAddress(mainNodeAddress);
     this.order = order;
     this.weight = weight;
-    this.resolve = resolve;
   }
 
   public String getRemoteAddressStr() {


### PR DESCRIPTION
Which again appeared somewhere in april 2020 when allowing disabling address resolution.
setInetSocketAddress was called first, before resolve was set, and caused resolve to be always false, disabling the resolve feature.